### PR TITLE
Throw exception on bad parameters to Prolific

### DIFF
--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -406,6 +406,9 @@ public class ProlificSerialDriver extends CommonUsbSerialDriver {
         case STOPBITS_2:
             lineRequestData[4] = 2;
             break;
+
+        default:
+            throw new IllegalArgumentException("Unknown stopBits value: " + stopBits);
         }
 
         switch (parity) {
@@ -428,6 +431,9 @@ public class ProlificSerialDriver extends CommonUsbSerialDriver {
         case PARITY_SPACE:
             lineRequestData[5] = 4;
             break;
+
+        default:
+            throw new IllegalArgumentException("Unknown parity value: " + parity);
         }
 
         lineRequestData[6] = (byte) dataBits;


### PR DESCRIPTION
This change causes an exception to be thrown if the user passes an invalid stop bit or parity value to the Prolific driver. This matches the current behavior of the FTDI driver.
