### PR TITLE
Implements Input/Output Stream helpers

### DIFF
--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialInputStream.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialInputStream.java
@@ -1,0 +1,46 @@
+package com.hoho.android.usbserial.stream;
+
+import com.hoho.android.usbserial.driver.UsbSerialDriver;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author lucas@creativa77.com.ar (Lucas Chiesa)
+ */
+class UsbSerialInputStream extends InputStream{
+
+    private final UsbSerialDriver device;
+    private final UsbSerialStreamFactory factory;
+
+    UsbSerialInputStream(UsbSerialDriver device, UsbSerialStreamFactory factory) {
+        this.device = device;
+        this.factory = factory;
+    }
+
+    @Override
+    public void close() throws IOException {
+        device.close();
+    }
+
+    @Override
+    public int read() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int read(byte[] buffer) throws IOException {
+        return read(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int count) throws IOException {
+        byte[] local_buffer = new byte[count];
+        if (offset < 0 || count < 0 || offset + count > buffer.length) {
+            throw new IndexOutOfBoundsException();
+        }
+        int byteCount;
+        byteCount = device.read(local_buffer, count);
+        System.arraycopy(local_buffer, 0, buffer, offset, byteCount);
+        return byteCount;
+    }
+}

--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialOutputStream.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialOutputStream.java
@@ -1,0 +1,45 @@
+package com.hoho.android.usbserial.stream;
+
+import com.hoho.android.usbserial.driver.UsbSerialDriver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * @author lucas@creativa77.com.ar (Lucas Chiesa)
+ */
+class UsbSerialOutputStream extends OutputStream {
+
+    private final UsbSerialDriver driver;
+    private final UsbSerialStreamFactory factory;
+
+    UsbSerialOutputStream(UsbSerialDriver driver, UsbSerialStreamFactory factory) {
+        this.driver = driver;
+        this.factory = factory;
+    }
+
+    @Override
+    public void close() throws IOException {
+        driver.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+    }
+
+    @Override
+    public void write(byte[] buffer, int offset, int count) throws java.io.IOException  {
+        if (offset < 0 || count < 0 || offset + count > buffer.length) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        byte[] local = new byte[count];
+        System.arraycopy(buffer, offset, local, 0, count);
+        this.driver.write(local, 1000);
+     }
+
+    @Override
+    public void write(int oneByte) throws IOException {
+        write(new byte[] { (byte) oneByte }, 0, 1);
+    }
+}

--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialStreamFactory.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/stream/UsbSerialStreamFactory.java
@@ -1,0 +1,74 @@
+package com.hoho.android.usbserial.stream;
+
+import com.hoho.android.usbserial.driver.UsbSerialDriver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * This helper class encapsulates a given <code>UsbSerialDriver</code> with implementations of
+ * <code>java.io.InputStream</code> and <code>java.io.OutputStream</code>.
+ *
+ * @author jcerruti@creativa77.com.ar (Julian Cerruti)
+ */
+public class UsbSerialStreamFactory {
+    private final UsbSerialDriver driver;
+
+    private final int baudRate;
+    private final int dataBits;
+    private final int stopBits;
+    private final int parity;
+
+    public UsbSerialStreamFactory(UsbSerialDriver driver, int baudRate, int dataBits, int stopBits, int parity) throws IOException {
+        this.driver = driver;
+        this.baudRate = baudRate;
+        this.dataBits = dataBits;
+        this.stopBits = stopBits;
+        this.parity = parity;
+
+        driver.open();
+        driver.setParameters(baudRate, dataBits, stopBits, parity);
+    }
+
+    /**
+     * Uses the following default values to open the underlying serial connection:
+     * - baud rante: 115200
+     * - data bits: 8
+     * - stop bits: 1
+     * - parity: none
+     */
+    public UsbSerialStreamFactory(UsbSerialDriver driver) throws IOException {
+        this(driver, 115200, UsbSerialDriver.DATABITS_8, UsbSerialDriver.STOPBITS_1, UsbSerialDriver.PARITY_NONE);
+    }
+
+    /**
+     * Closes the underlying driver's serial connection
+     */
+    public void close() throws IOException {
+        driver.close();
+    }
+
+    public InputStream getInputStream() {
+        return new UsbSerialInputStream(this.driver, this);
+    }
+    public OutputStream getOutputStream() {
+        return new UsbSerialOutputStream(this.driver, this);
+    }
+
+    public int getStopBits() {
+        return stopBits;
+    }
+
+    public int getParity() {
+        return parity;
+    }
+
+    public int getDataBits() {
+        return dataBits;
+    }
+
+    public int getBaudRate() {
+        return baudRate;
+    }
+}


### PR DESCRIPTION
Add Input and Output Streams around driver objects. These streams are
created with a Factory which takes care of opening and configuring the
driver before creating the streams.

Having the streams is very useful when mixing this library with third
party modules, which expect Java streams as input/output.
