### PR TITLE
Add UTM-30LX laser to the supported ACM devices.

### DIFF
--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -242,6 +242,10 @@ public class CdcAcmSerialDriver extends CommonUsbSerialDriver {
                 new int[] {
                     UsbId.LEAFLABS_MAPLE,
                 });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_HOKUYO),
+                new int[] {
+                    UsbId.HOKUYO_UTM30LX,
+                });
         return supportedDevices;
     }
 

--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/UsbId.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/UsbId.java
@@ -59,6 +59,9 @@ public final class UsbId {
     public static final int VENDOR_PROLIFIC = 0x067b;
     public static final int PROLIFIC_PL2303 = 0x2303;
 
+    public static final int VENDOR_HOKUYO = 0x15D1;
+    public static final int HOKUYO_UTM30LX = 0x0;
+
     private UsbId() {
         throw new IllegalAccessError("Non-instantiable class.");
     }


### PR DESCRIPTION
UTM-30LX is a Hokuyo laser range finder, quite commonly used in robotics
applications. It presents an ACM interface, and there are Java libraries
that work well in Android in conjunction with this library to access the
range information.
