### PR TITLE
Corrected USB Control Request Type definitions

### DIFF
--- a/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/UsbSerialLibrary/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -90,9 +90,9 @@ import java.util.Map;
 public class FtdiSerialDriver extends CommonUsbSerialDriver {
 
     public static final int USB_TYPE_STANDARD = 0x00 << 5;
-    public static final int USB_TYPE_CLASS = 0x00 << 5;
-    public static final int USB_TYPE_VENDOR = 0x00 << 5;
-    public static final int USB_TYPE_RESERVED = 0x00 << 5;
+    public static final int USB_TYPE_CLASS = 0x01 << 5;
+    public static final int USB_TYPE_VENDOR = 0x02 << 5;
+    public static final int USB_TYPE_RESERVED = 0x03 << 5;
 
     public static final int USB_RECIP_DEVICE = 0x00;
     public static final int USB_RECIP_INTERFACE = 0x01;


### PR DESCRIPTION
Even though they are not being used, might as well set them right. The other option would be to delete these four lines. For reference, http://www.beyondlogic.org/usbnutshell/usb6.shtml

SIgned-off-by Venkatesh Shukla venkatesh.shukla.eee11@iitbhu.ac.in
