### PR TITLE
Update ProlificSerialDriver.java

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -456,6 +456,10 @@ public class ProlificSerialDriver implements UsbSerialDriver {
             case PARITY_ODD:
                 lineRequestData[5] = 1;
                 break;
+            
+            case PARITY_EVEN:
+                lineRequestData[5] = 2;
+                break;
 
             case PARITY_MARK:
                 lineRequestData[5] = 3;


### PR DESCRIPTION
Missing Parity case in switch statement causes the Prolific driver code to crash when Parity is set to Even.