### PR TITLE
Add device ID for proxmark3 (CDC ACM)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/usbSerialForAndroid/build.gradle
+++ b/usbSerialForAndroid/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.1"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 12

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -426,6 +426,10 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                 new int[] {
                     UsbId.LEAFLABS_MAPLE,
                 });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_PROXMARK3),
+                new int[] {
+                    UsbId.PROXMARK3,
+                });
         return supportedDevices;
     }
 

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -90,7 +90,7 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
 
         public CdcAcmSerialPort(UsbDevice device, int portNumber) {
             super(device, portNumber);
-            mEnableAsyncReads = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1);
+            mEnableAsyncReads = false; // (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1);
         }
 
         @Override

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -401,7 +401,7 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
 
     public static Map<Integer, int[]> getSupportedDevices() {
         final Map<Integer, int[]> supportedDevices = new LinkedHashMap<Integer, int[]>();
-        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ARDUINO),
+        supportedDevices.put(UsbId.VENDOR_ARDUINO,
                 new int[] {
                         UsbId.ARDUINO_UNO,
                         UsbId.ARDUINO_UNO_R3,
@@ -414,21 +414,25 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                         UsbId.ARDUINO_LEONARDO,
                         UsbId.ARDUINO_MICRO,
                 });
-        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_VAN_OOIJEN_TECH),
+        supportedDevices.put(UsbId.VENDOR_VAN_OOIJEN_TECH,
                 new int[] {
                     UsbId.VAN_OOIJEN_TECH_TEENSYDUINO_SERIAL,
                 });
-        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ATMEL),
+        supportedDevices.put(UsbId.VENDOR_ATMEL,
                 new int[] {
                     UsbId.ATMEL_LUFA_CDC_DEMO_APP,
                 });
-        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_LEAFLABS),
+        supportedDevices.put(UsbId.VENDOR_LEAFLABS,
                 new int[] {
                     UsbId.LEAFLABS_MAPLE,
                 });
-        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_PROXMARK3),
+        supportedDevices.put(UsbId.VENDOR_PROXMARK3,
                 new int[] {
                     UsbId.PROXMARK3,
+                });
+        supportedDevices.put(UsbId.VENDOR_PROXMARK3_OLD,
+                new int[] {
+                    UsbId.PROXMARK3_OLD,
                 });
         return supportedDevices;
     }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
@@ -56,6 +56,9 @@ public final class UsbId {
     public static final int VENDOR_LEAFLABS = 0x1eaf;
     public static final int LEAFLABS_MAPLE = 0x0004;
 
+    public static final int VENDOR_PROXMARK3 = 0x2d2d;
+    public static final int PROXMARK3 = 0x504d;
+
     public static final int VENDOR_SILABS = 0x10c4;
     public static final int SILABS_CP2102 = 0xea60;
     public static final int SILABS_CP2105 = 0xea70;

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
@@ -56,8 +56,12 @@ public final class UsbId {
     public static final int VENDOR_LEAFLABS = 0x1eaf;
     public static final int LEAFLABS_MAPLE = 0x0004;
 
-    public static final int VENDOR_PROXMARK3 = 0x2d2d;
-    public static final int PROXMARK3 = 0x504d;
+    // Older firmware uses unregistered IDs
+    public static final int VENDOR_PROXMARK3_OLD = 0x2d2d;
+    public static final int PROXMARK3_OLD = 0x504d;
+
+    public static final int VENDOR_PROXMARK3 = 0x9ac4;
+    public static final int PROXMARK3 = 0x4b8f;
 
     public static final int VENDOR_SILABS = 0x10c4;
     public static final int SILABS_CP2102 = 0xea60;


### PR DESCRIPTION
proxmark3 acts as a USB CDC ACM device. This whitelists it's device ID (2d2d:504d) to be used by the CdcAcmSerialDriver.

This appears to work correctly in a test program.
