### PR TITLE
CH34x: data bits, parity, stop bits

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
@@ -264,26 +264,38 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
                     configDataBits |= 0x0800;
                     break;
                 default:
-                    configDataBits |= 0x0800;
-                    break;
+                    throw new IllegalArgumentException("Unknown dataBits value: " + dataBits);
             }
             
             switch (parity) {
+                case PARITY_NONE:
+                    break;
                 case PARITY_ODD:
                     configDataBits |= 0x0010;
                     break;
                 case PARITY_EVEN:
                     configDataBits |= 0x0020;
                     break;
+                case PARITY_MARK:
+                    configDataBits |= 0x0030;
+                    break;
+                case PARITY_SPACE:
+                    configDataBits |= 0x0040;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown parity value: " + parity);
             }
             
             switch (stopBits) {
                 case STOPBITS_1:
-                    configDataBits |= 0;
                     break;
+                case STOPBITS_1_5:
+                    throw new IllegalArgumentException("Unsupported stopBits value: 1.5");
                 case STOPBITS_2:
                     configDataBits |= 2;
                     break;
+                default:
+                    throw new IllegalArgumentException("Unknown stopBits value: " + stopBits);
             }
             setConfigSingle(SILABSER_SET_LINE_CTL_REQUEST_CODE, configDataBits);
         }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -379,7 +379,18 @@ public class FtdiSerialDriver implements UsbSerialDriver {
                 throws IOException {
             setBaudRate(baudRate);
 
-            int config = dataBits;
+            int config = 0;
+            switch (dataBits) {
+                case DATABITS_5:
+                case DATABITS_6:
+                    throw new IllegalArgumentException("Unsupported dataBits value: " + dataBits);
+                case DATABITS_7:
+                case DATABITS_8:
+                    config |= dataBits;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown dataBits value: " + dataBits);
+            }
 
             switch (parity) {
                 case PARITY_NONE:
@@ -406,8 +417,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
                     config |= (0x00 << 11);
                     break;
                 case STOPBITS_1_5:
-                    config |= (0x01 << 11);
-                    break;
+                    throw new IllegalArgumentException("Unsupported stopBits value: 1.5");
                 case STOPBITS_2:
                     config |= (0x02 << 11);
                     break;


### PR DESCRIPTION
CP21xx: mark+space
all devices: return error on unsupported parameters

implemented similar to linux kernel.
verified signal waveform with good old HAMEG 203 scope