### PR TITLE
Added RawUsb library and updated CDC-ACM driver

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmDriverUpdated.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmDriverUpdated.java
@@ -1,0 +1,454 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.hardware.usb.UsbRequest;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import justin.RawUsbConfiguration;
+import justin.RawUsbDevice;
+import justin.RawUsbFunctionInterface;
+import justin.RawUsbFunctionUnion;
+import justin.RawUsbInterface;
+import justin.RawUsbManager;
+
+public class CdcAcmDriverUpdated implements UsbSerialDriver{
+
+    private final String TAG = CdcAcmDriverUpdated.class.getSimpleName();
+
+    private UsbDevice mDevice;
+    private RawUsbDevice mRawDevice = null;
+
+    private final UsbSerialPort mPort;
+
+    public CdcAcmDriverUpdated(UsbDevice device){
+        this.mDevice = device;
+        mPort = new CdcAcmCompleteSerialPort(device, 0);
+    }
+
+    @Override
+    public UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    @Override
+    public List<UsbSerialPort> getPorts() {
+        return Collections.singletonList(mPort);
+    }
+
+    public class CdcAcmCompleteSerialPort extends CommonUsbSerialPort {
+
+        private final boolean mEnableAsyncReads;
+        private UsbInterface mControlInterface;
+        private UsbInterface mDataInterface;
+
+        private UsbEndpoint mControlEndpoint;
+        private UsbEndpoint mReadEndpoint;
+        private UsbEndpoint mWriteEndpoint;
+
+        private boolean mRts = false;
+        private boolean mDtr = false;
+
+        private ArrayList<CdcAcmVirtualSerialPort> mSerialPorts;
+        private int defaultVirtualPortIndex = 0;
+
+        private static final int USB_RECIP_INTERFACE = 0x01;
+        private static final int USB_RT_ACM = UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+
+        private static final int SET_LINE_CODING = 0x20;  // USB CDC 1.1 section 6.2
+        private static final int GET_LINE_CODING = 0x21;
+        private static final int SET_CONTROL_LINE_STATE = 0x22;
+        private static final int SEND_BREAK = 0x23;
+
+        public CdcAcmCompleteSerialPort(UsbDevice device, int portNumber) {
+            super(device, portNumber);
+            mEnableAsyncReads = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1);
+            mSerialPorts = new ArrayList<CdcAcmVirtualSerialPort>();
+        }
+
+        @Override
+        public UsbSerialDriver getDriver() {
+            return CdcAcmDriverUpdated.this;
+        }
+
+        @Override
+        public void open(UsbDeviceConnection connection) throws IOException{
+            populateSerialPorts(connection);
+
+            if (mSerialPorts.isEmpty()){
+                throw new IOException("No CDC ACM Ports found!");
+            } else {
+                Log.d(TAG,"Number of serial ports found:"+mSerialPorts.size());
+
+                //Open the first serial port found by default.
+                try {
+                    open(defaultVirtualPortIndex);
+                } catch (IndexOutOfBoundsException e){
+                    Log.d(TAG, "Virtual port was not found");
+                }
+            }
+        }
+
+        private void open(int mPortNumber) throws IOException{
+            CdcAcmVirtualSerialPort mPort = mSerialPorts.get(mPortNumber);
+
+            mControlInterface = mPort.getControlInterface();
+            mDataInterface = mPort.getDataInterface();
+
+            mControlEndpoint = mPort.getControlEndpoint();
+            mReadEndpoint = mPort.getReadEndpoint();
+            mWriteEndpoint = mPort.getWriteEndpoint();
+
+            if (!mConnection.claimInterface(mDataInterface,true)){
+                Log.d(TAG, "Could not claim interface.");
+            } else {
+                Log.d(TAG, "Claimed interface.");
+            }
+        }
+
+        public void populateSerialPorts(UsbDeviceConnection connection) throws IOException{
+            mSerialPorts.clear();
+            mConnection = connection;
+
+            //This accesses the "RawUsb" package
+            mRawDevice = RawUsbManager.getDeviceFromRawString(connection.getRawDescriptors());
+
+            if (mRawDevice == null) {
+                return;
+            }
+
+            //Doing both of the following operations allows for several "virtual" serial
+            //ports on a single device
+
+            //Find any possible serial ports defined by a union functional descriptor
+            ArrayList<RawUsbFunctionUnion> mUnions = getUnionDescriptors(mRawDevice);
+            //Find any possible castrated serial ports that are defined with only 1 interface
+            ArrayList<RawUsbInterface> mSingles = getSingleInterfaces(mRawDevice);
+
+            setupSerialPorts(mUnions,mSingles);
+        }
+
+        public int getSerialPortCount(){
+            return mSerialPorts.size();
+        }
+
+        public CdcAcmVirtualSerialPort getSerialPort(int index){
+            return mSerialPorts.get(index);
+        }
+
+        public void setDefaultVirtualPort(CdcAcmVirtualSerialPort v){
+            int index = 0;
+            //Finds appropriate virtual port and then sets the index.
+            for (CdcAcmVirtualSerialPort temp : mSerialPorts){
+                if (temp == v){
+                    defaultVirtualPortIndex = index;
+                }
+                index++;
+            }
+        }
+
+        public void setDefaultVirtualPortIndex(int defaultVirtualPortIndex) {
+            this.defaultVirtualPortIndex = defaultVirtualPortIndex;
+        }
+
+        public int getDefaultVirtualPortIndex(){
+            return this.defaultVirtualPortIndex;
+        }
+
+        private void setupSerialPorts(ArrayList<RawUsbFunctionUnion> unions,
+                                      ArrayList<RawUsbInterface> singles)
+                                        throws IOException{
+            if (unions.isEmpty() && singles.isEmpty()){
+                throw new IOException("No Serial Interfaces found");
+            }
+
+            for (RawUsbFunctionUnion union : unions){
+                mSerialPorts.add(getSerialFromUnion(union));
+            }
+
+            for (RawUsbInterface iface : singles){
+                mSerialPorts.add(getSerialFromSingleInterface(iface));
+            }
+        }
+
+        private CdcAcmVirtualSerialPort getSerialFromUnion(RawUsbFunctionUnion union) throws IOException{
+
+            //Get appropriate interface id numbers
+            int dataInterfaceNumber = union.getSlaveInterface(0);
+            int controlInterfaceNumber = union.getMasterInterface();
+
+            UsbInterface controlIface;
+            UsbInterface dataIface;
+
+            //Get actual interfaces from id numbers
+            dataIface = getInterfaceFromId(dataInterfaceNumber);
+            if (dataIface == null){
+                Log.d(TAG,"Slave interface number is incorrect");
+                throw new IOException("Slave interface number is incorrect");
+            }
+
+            controlIface = getInterfaceFromId(controlInterfaceNumber);
+            if (controlIface == null){
+                Log.d(TAG,"Master interface number is incorrect");
+                throw new IOException("Master interface number is incorrect");
+            }
+
+            CdcAcmVirtualSerialPort mSerial = new CdcAcmVirtualSerialPort(controlIface,dataIface);
+            return mSerial;
+        }
+
+        private CdcAcmVirtualSerialPort getSerialFromSingleInterface(RawUsbInterface i) throws IOException{
+            return new CdcAcmVirtualSerialPort(getInterfaceFromId(i.getNumber()),
+                    getInterfaceFromId(i.getNumber()));
+        }
+
+        //This ONLY checks union for CDC ACM interfaces.
+        private ArrayList<RawUsbFunctionUnion> getUnionDescriptors(RawUsbDevice d){
+            ArrayList<RawUsbFunctionUnion> u = new ArrayList<RawUsbFunctionUnion>();
+
+            //Assumes only one configuration on device
+            RawUsbConfiguration c = d.getConfiguration(0);
+            RawUsbInterface mInterface;
+            RawUsbFunctionInterface mFunc;
+
+            //Iterate through every interface
+            for (int i = 0; i < c.getInterfaceCount(); i++){
+                mInterface = c.getInterface(i);
+
+                //Only looks for interfaces of the communications class to be read as serial.
+                if (mInterface.getInterfaceClass() == 2 && mInterface.getInterfaceSubclass() == 2) {
+                    //Iterate through every functional descriptor
+                    for (int j = 0; j < mInterface.getFunctionalDescriptorCount(); j++) {
+                        mFunc = mInterface.getFunctionalDescriptor(j);
+                        //Save the union descriptor to the arraylist
+                        if (mFunc instanceof RawUsbFunctionUnion) {
+                            u.add((RawUsbFunctionUnion) mFunc);
+                        }
+                    }
+                }
+            }
+
+            if (u.isEmpty()){
+                Log.d(TAG,"Did not find any Union Descriptors.");
+            }
+
+            return u;
+        }
+
+        private ArrayList<RawUsbInterface> getSingleInterfaces(RawUsbDevice d){
+            ArrayList<RawUsbInterface> singles = new ArrayList<RawUsbInterface>();
+
+            for (int i = 0; i < d.getInterfaceCount(); i++){
+                RawUsbInterface tempInterface = d.getInterface(i);
+                //Only investigates interfaces that are CDC ACM
+                if (tempInterface.getInterfaceClass() == 2 &&
+                        tempInterface.getInterfaceSubclass() == 2){
+                    //3 endpoints could mean this is a castrated CDC ACM device
+                    if (tempInterface.getEndpointCount() == 3){
+                        singles.add(tempInterface);
+                    }
+                }
+            }
+
+            return singles;
+        }
+
+        private UsbInterface getInterfaceFromId(int id){
+            for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                UsbInterface tempInt = mDevice.getInterface(i);
+
+                if (tempInt.getId() == id){
+                    return tempInt;
+                }
+            }
+
+            return null;
+        }
+
+        private int sendAcmControlMessage(int request, int value, byte[] buf) {
+            return mConnection.controlTransfer(
+                    USB_RT_ACM, request, value, 0, buf, buf != null ? buf.length : 0, 5000);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (mConnection == null) {
+                throw new IOException("Already closed");
+            }
+            mConnection.close();
+            mConnection = null;
+        }
+
+        @Override
+        public int read(byte[] dest, int timeoutMillis) throws IOException {
+            if (mEnableAsyncReads) {
+                final UsbRequest request = new UsbRequest();
+                try {
+                    request.initialize(mConnection, mReadEndpoint);
+                    final ByteBuffer buf = ByteBuffer.wrap(dest);
+                    if (!request.queue(buf, dest.length)) {
+                        throw new IOException("Error queueing request.");
+                    }
+
+                    final UsbRequest response = mConnection.requestWait();
+                    if (response == null) {
+                        throw new IOException("Null response");
+                    }
+
+                    final int nread = buf.position();
+                    if (nread > 0) {
+                        //Log.d(TAG, HexDump.dumpHexString(dest, 0, Math.min(32, dest.length)));
+                        return nread;
+                    } else {
+                        return 0;
+                    }
+                } finally {
+                    request.close();
+                }
+            }
+
+            final int numBytesRead;
+            synchronized (mReadBufferLock) {
+                int readAmt = Math.min(dest.length, mReadBuffer.length);
+                numBytesRead = mConnection.bulkTransfer(mReadEndpoint, mReadBuffer, readAmt,
+                        timeoutMillis);
+                if (numBytesRead < 0) {
+                    // This sucks: we get -1 on timeout, not 0 as preferred.
+                    // We *should* use UsbRequest, except it has a bug/api oversight
+                    // where there is no way to determine the number of bytes read
+                    // in response :\ -- http://b.android.com/28023
+                    if (timeoutMillis == Integer.MAX_VALUE) {
+                        // Hack: Special case "~infinite timeout" as an error.
+                        return -1;
+                    }
+                    return 0;
+                }
+                System.arraycopy(mReadBuffer, 0, dest, 0, numBytesRead);
+            }
+            return numBytesRead;
+        }
+
+        @Override
+        public int write(byte[] src, int timeoutMillis) throws IOException {
+            // TODO(mikey): Nearly identical to FtdiSerial write. Refactor.
+            int offset = 0;
+
+            while (offset < src.length) {
+                final int writeLength;
+                final int amtWritten;
+
+                synchronized (mWriteBufferLock) {
+                    final byte[] writeBuffer;
+
+                    writeLength = Math.min(src.length - offset, mWriteBuffer.length);
+                    if (offset == 0) {
+                        writeBuffer = src;
+                    } else {
+                        // bulkTransfer does not support offsets, make a copy.
+                        System.arraycopy(src, offset, mWriteBuffer, 0, writeLength);
+                        writeBuffer = mWriteBuffer;
+                    }
+
+                    amtWritten = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, writeLength,
+                            timeoutMillis);
+                }
+                if (amtWritten <= 0) {
+                    throw new IOException("Error writing " + writeLength
+                            + " bytes at offset " + offset + " length=" + src.length);
+                }
+
+                Log.d(TAG, "Wrote amt=" + amtWritten + " attempted=" + writeLength);
+                offset += amtWritten;
+            }
+            return offset;
+        }
+
+        @Override
+        public void setParameters(int baudRate, int dataBits, int stopBits, int parity) {
+            byte stopBitsByte;
+            switch (stopBits) {
+                case STOPBITS_1: stopBitsByte = 0; break;
+                case STOPBITS_1_5: stopBitsByte = 1; break;
+                case STOPBITS_2: stopBitsByte = 2; break;
+                default: throw new IllegalArgumentException("Bad value for stopBits: " + stopBits);
+            }
+
+            byte parityBitesByte;
+            switch (parity) {
+                case PARITY_NONE: parityBitesByte = 0; break;
+                case PARITY_ODD: parityBitesByte = 1; break;
+                case PARITY_EVEN: parityBitesByte = 2; break;
+                case PARITY_MARK: parityBitesByte = 3; break;
+                case PARITY_SPACE: parityBitesByte = 4; break;
+                default: throw new IllegalArgumentException("Bad value for parity: " + parity);
+            }
+
+            byte[] msg = {
+                    (byte) ( baudRate & 0xff),
+                    (byte) ((baudRate >> 8 ) & 0xff),
+                    (byte) ((baudRate >> 16) & 0xff),
+                    (byte) ((baudRate >> 24) & 0xff),
+                    stopBitsByte,
+                    parityBitesByte,
+                    (byte) dataBits};
+            sendAcmControlMessage(SET_LINE_CODING, 0, msg);
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return false;  // TODO
+        }
+
+        @Override
+        public boolean getCTS() throws IOException {
+            return false;  // TODO
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return false;  // TODO
+        }
+
+        @Override
+        public boolean getDTR() throws IOException {
+            return mDtr;
+        }
+
+        @Override
+        public void setDTR(boolean value) throws IOException {
+            mDtr = value;
+            setDtrRts();
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return false;  // TODO
+        }
+
+        @Override
+        public boolean getRTS() throws IOException {
+            return mRts;
+        }
+
+        @Override
+        public void setRTS(boolean value) throws IOException {
+            mRts = value;
+            setDtrRts();
+        }
+
+        private void setDtrRts() {
+            int value = (mRts ? 0x2 : 0) | (mDtr ? 0x1 : 0);
+            sendAcmControlMessage(SET_CONTROL_LINE_STATE, value, null);
+        }
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmVirtualSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmVirtualSerialPort.java
@@ -1,0 +1,150 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static android.hardware.usb.UsbConstants.USB_DIR_OUT;
+
+public class CdcAcmVirtualSerialPort {
+
+    private UsbEndpoint mControlEndpoint;
+    private UsbEndpoint mReadEndpoint;
+    private UsbEndpoint mWriteEndpoint;
+
+    private UsbInterface mControlInterface;
+    private UsbInterface mDataInterface;
+
+    private String mName = "";
+
+    public CdcAcmVirtualSerialPort(UsbInterface control, UsbInterface data) throws IOException{
+        mControlInterface = control;
+        mDataInterface = data;
+
+        if (mControlInterface == null || mDataInterface == null){
+            throw new IOException("Control and Data interfaces are null");
+        }
+
+        if (mControlInterface == mDataInterface){
+            setupSingleInterface();
+        } else {
+            setupUnionInterfaces();
+        }
+
+        setName();
+    }
+
+    public String getName(){
+        return mName;
+    }
+
+    private void setName(){
+        //Searches the string representation of the interfaces for 'mName'
+        //Then it pulls whatever is after '=' as the name of the interface.
+        String idata1 = mControlInterface.toString();
+        String idata2 = mDataInterface.toString();
+        Pattern pattern = Pattern.compile("mName=(.*?),");
+        Matcher matcher1 = pattern.matcher(idata1);
+        Matcher matcher2 = pattern.matcher(idata2);
+
+        String temp1 = null, temp2 = null;
+        if (matcher1.find()){
+            temp1 = matcher1.group(1);
+        }
+        if (matcher2.find()){
+            temp2 = matcher2.group(1);
+        }
+
+        //Set the name to the control interface if it's not null.
+        //Then try the data interface. If both are null, create
+        //a name based off of the control interface's id number.
+        if (temp1 != null && !temp1.equals("null")){
+            mName = temp1;
+        } else if (temp2 != null && !temp2.equals("null")){
+            mName = temp2;
+        } else {
+            mName = "mControlId: " + mControlInterface.getId();
+        }
+    }
+
+    private void setupSingleInterface() throws IOException{
+        mControlEndpoint = null;
+        mReadEndpoint = null;
+        mWriteEndpoint = null;
+
+        int endCount = mControlInterface.getEndpointCount();
+
+        for (int i = 0; i < endCount; ++i) {
+            UsbEndpoint ep = mControlInterface.getEndpoint(i);
+            if ((ep.getDirection() == UsbConstants.USB_DIR_IN) &&
+                    (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_INT)) {
+                //Found control endpoint
+                mControlEndpoint = ep;
+            } else if ((ep.getDirection() == UsbConstants.USB_DIR_IN) &&
+                    (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                //Found reading endpoint
+                mReadEndpoint = ep;
+            } else if ((ep.getDirection() == UsbConstants.USB_DIR_OUT) &&
+                    (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)) {
+                //Found writing endpoint
+                mWriteEndpoint = ep;
+            }
+        }
+
+        if ((mControlEndpoint == null) ||
+                (mReadEndpoint == null) ||
+                (mWriteEndpoint == null)) {
+            throw new IOException("Could not establish all endpoints");
+        }
+    }
+
+    private void setupUnionInterfaces() throws IOException{
+        mControlEndpoint = null;
+        mReadEndpoint = null;
+        mWriteEndpoint = null;
+
+        //Picks first endpoint in control interface (there should only be one).
+        mControlEndpoint = mControlInterface.getEndpoint(0);
+        for (int i = 0; i < mDataInterface.getEndpointCount(); i++){
+            UsbEndpoint tempEP = mDataInterface.getEndpoint(i);
+
+            //USB OUT is "host to device" - so we write to it
+            if (tempEP.getDirection() == USB_DIR_OUT){
+                mWriteEndpoint = tempEP;
+            } else {
+                //USB IN is "device to host" - so we read from it
+                mReadEndpoint = tempEP;
+            }
+        }
+
+        if ((mControlEndpoint == null) ||
+                (mReadEndpoint == null) ||
+                (mWriteEndpoint == null)) {
+            throw new IOException("Could not establish all endpoints");
+        }
+    }
+
+    public UsbEndpoint getControlEndpoint() {
+        return mControlEndpoint;
+    }
+
+    public UsbEndpoint getReadEndpoint() {
+        return mReadEndpoint;
+    }
+
+    public UsbEndpoint getWriteEndpoint() {
+        return mWriteEndpoint;
+    }
+
+    public UsbInterface getControlInterface() {
+        return mControlInterface;
+    }
+
+    public UsbInterface getDataInterface() {
+        return mDataInterface;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/DescriptorException.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/DescriptorException.java
@@ -1,0 +1,17 @@
+package justin;
+
+public class DescriptorException extends Exception {
+}
+
+class IncorrectDescriptorException extends DescriptorException {
+    private int type;
+    public IncorrectDescriptorException(int type){
+        this.type = type;
+    }
+    public int getType(){
+        return this.type;
+    }
+}
+
+class BadDescriptorException extends DescriptorException {
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbConfiguration.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbConfiguration.java
@@ -1,0 +1,90 @@
+package justin;
+
+import java.util.ArrayList;
+
+import static justin.RawUsbManager.CONFIGURATION_TYPE;
+
+public class RawUsbConfiguration {
+    private int bLength,bDescriptorType,wTotalLength,bNumInterfaces,bConfigurationValue,
+                iConfiguration,bMaxPower;
+    private byte bmAttributes;
+    private ArrayList<RawUsbInterface> interfaces;
+    private ArrayList<RawUsbOtherDescriptor> others;
+
+    public RawUsbConfiguration(byte[] desc) throws DescriptorException{
+        bLength = byteToInt(desc[0]);
+        bDescriptorType = byteToInt(desc[1]);
+
+        //if the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != CONFIGURATION_TYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //if the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bLength){throw new BadDescriptorException();}
+
+        wTotalLength = bytesToInt(desc[3],desc[2]);
+        bNumInterfaces = byteToInt(desc[4]);
+        bConfigurationValue = byteToInt(desc[5]);
+        iConfiguration = byteToInt(desc[6]);
+        bmAttributes = desc[7];
+        bMaxPower = byteToInt(desc[8]);
+
+        interfaces = new ArrayList<RawUsbInterface>();
+        others = new ArrayList<RawUsbOtherDescriptor>();
+    }
+
+    public RawUsbInterface getInterface(int index){
+        return interfaces.get(index);
+    }
+
+    public int getInterfaceCount(){
+        return interfaces.size();
+    }
+
+    public void addInterface(RawUsbInterface i){
+        interfaces.add(i);
+    }
+
+    public void addOther(RawUsbOtherDescriptor o){
+        others.add(o);
+    }
+
+    public int getTotalLength(){
+        return wTotalLength;
+    }
+
+    public int getLength(){
+        return bLength;
+    }
+
+    public String toString(){
+        String out = "  Configuration descriptor:\n";
+
+        out += String.format("    Length:             %5d\n",bLength);
+        out += String.format("    Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("    Total Length:       %5d\n",wTotalLength);
+        out += String.format("    NumInterfaces:      %5d\n",bNumInterfaces);
+        out += String.format("    Configuration Value:%5d\n", bConfigurationValue);
+        out += String.format("    ConfigIndex:        %5d\n", iConfiguration);
+        out += String.format("    Attributes:         %5s\n", "0x"+ Integer.toHexString(bmAttributes & 0xFF));
+        out += String.format("    Max Power:          %5d\n", bMaxPower*2);
+
+        for (RawUsbInterface i : interfaces){
+            out += i.toString();
+        }
+
+        for (RawUsbOtherDescriptor o : others){
+            out += o.toString();
+        }
+
+        return out;
+    }
+
+    private int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+
+    private int bytesToInt(byte b, byte c){
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        return (b2 << 8) | c2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbDevice.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbDevice.java
@@ -1,0 +1,118 @@
+package justin;
+
+import java.util.ArrayList;
+
+import static justin.RawUsbManager.DEVICE_TYPE;
+
+public class RawUsbDevice {
+
+    private int bLength,bDescriptorType,bcdUSB,bDeviceClass,bDeviceSubClass,bDeviceProtocol,
+                bMaxPacketSize0,idVendor,idProduct,bcdDevice,iManufacturer,
+                iProduct,iSerialNumber,bNumConfigurations;
+
+    private ArrayList<RawUsbConfiguration> configs;
+
+    public RawUsbDevice(byte[] desc) throws DescriptorException{
+        bLength = byteToInt(desc[0]);
+        bDescriptorType = byteToInt(desc[1]);
+
+        //if the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != DEVICE_TYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //if the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bLength){throw new BadDescriptorException();}
+
+        bcdUSB = bytesToInt(desc[3],desc[2]);
+        bDeviceClass = byteToInt(desc[4]);
+        bDeviceSubClass = byteToInt(desc[5]);
+        bDeviceProtocol = byteToInt(desc[6]);
+        bMaxPacketSize0 = byteToInt(desc[7]);
+        idVendor = bytesToInt(desc[9],desc[8]);
+        idProduct = bytesToInt(desc[11],desc[10]);
+        bcdDevice = bytesToInt(desc[13],desc[12]);
+        iManufacturer = byteToInt(desc[14]);
+        iProduct = byteToInt(desc[15]);
+        iSerialNumber = byteToInt(desc[16]);
+        bNumConfigurations = byteToInt(desc[17]);
+
+        configs = new ArrayList<RawUsbConfiguration>();
+    }
+
+    public int getVendorId() {
+        return idVendor;
+    }
+
+    public int getProductId(){
+        return idProduct;
+    }
+
+    public int getConfigurationCount(){
+        return bNumConfigurations;
+    }
+
+    public int getInterfaceCount(){
+        int total = 0;
+        for (RawUsbConfiguration c : configs){
+            total += c.getInterfaceCount();
+        }
+        return total;
+    }
+
+    public RawUsbInterface getInterface(int index){
+        return configs.get(0).getInterface(index);
+    }
+
+    public void addConfiguration(RawUsbConfiguration c){
+        configs.add(c);
+    }
+
+    public RawUsbConfiguration getConfiguration(int index){
+        return configs.get(index);
+    }
+
+    //Gets an interface based off of the interface's internal ID, not the index in the
+    //devices array.
+    public RawUsbInterface getInterfaceByNumber(int num){
+        RawUsbConfiguration c = configs.get(0);
+        for (int i = 0; i < c.getInterfaceCount(); i++){
+            RawUsbInterface tempInterface = c.getInterface(i);
+            if (tempInterface.getNumber() == num) return tempInterface;
+        }
+
+        return null;
+    }
+
+    public String toString(){
+        String out = "Device Descriptor:\n";
+
+        out += String.format("  Length:             %5d\n",bLength);
+        out += String.format("  Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("  BcdUSB:        %10s\n", "0x"+ Integer.toHexString(bcdUSB));
+        out += String.format("  Device Class:       %5d\n",bDeviceClass);
+        out += String.format("  Device Subclass:    %5d\n",bDeviceSubClass);
+        out += String.format("  Device Protocol:    %5d\n",bDeviceProtocol);
+        out += String.format("  MaxPacketSize0:     %5d\n",bMaxPacketSize0);
+        out += String.format("  Vendor ID:     %10s\n", "0x"+ Integer.toHexString(idVendor));
+        out += String.format("  Product ID:    %10s\n", "0x"+ Integer.toHexString(idProduct));
+        out += String.format("  BcdDevice:     %10s\n", "0x"+ Integer.toHexString(bcdDevice));
+        out += String.format("  Manufacturer Index: %5d\n",iManufacturer);
+        out += String.format("  Product Index:      %5d\n",iProduct);
+        out += String.format("  Serial Index:       %5d\n",iSerialNumber);
+        out += String.format("  NumConfigurations:  %5d\n",bNumConfigurations);
+
+        for (RawUsbConfiguration c : configs){
+            out += c.toString();
+        }
+
+        return out;
+    }
+
+    private int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+
+    private int bytesToInt(byte b, byte c){
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        return (b2 << 8) | c2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbEndpoint.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbEndpoint.java
@@ -1,0 +1,61 @@
+package justin;
+
+import static justin.RawUsbManager.ENDPOINT_TYPE;
+
+public class RawUsbEndpoint {
+    private int bLength,bDescriptorType,bEndpointAddress,
+                wMaxPacketSize,bInterval;
+    private byte bmAttributes;
+
+    public RawUsbEndpoint(byte[] desc) throws DescriptorException{
+        bLength = byteToInt(desc[0]);
+        bDescriptorType = byteToInt(desc[1]);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != ENDPOINT_TYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bLength){throw new BadDescriptorException();}
+
+        bEndpointAddress = desc[2];
+        bmAttributes = desc[3];
+        wMaxPacketSize = bytesToInt(desc[5],desc[4]);
+        bInterval = byteToInt(desc[6]);
+    }
+
+    public int getEndpointDirection(){
+        //0 is OUT, 1 (or non-zero) is IN.
+        return bEndpointAddress & 0b10000000;
+    }
+
+    public boolean isIn(){
+        if (getEndpointDirection() != 0) return true;
+        return false;
+    }
+
+    public String toString(){
+        String out = "      Endpoint Descriptor:\n";
+
+        out += String.format("        Length:             %5d\n", bLength);
+        out += String.format("        Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("        Address:       %10s\n",
+                "0x"+ Integer.toHexString(bEndpointAddress & 0xff)+
+                        (isIn() ? "(IN)" : "(OUT)"));
+        out += String.format("        Attributes:    %10s\n", "0x"+ Integer.toHexString(bmAttributes));
+        out += String.format("        Max Packet Size:%9s\n", "0x"+ Integer.toHexString(wMaxPacketSize));
+        out += String.format("        bInterval:          %5d\n",bInterval);
+
+        return out;
+    }
+
+    private int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+
+    private int bytesToInt(byte b, byte c){
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        return (b2 << 8) | c2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionACM.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionACM.java
@@ -1,0 +1,27 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_ACM_SUBTYPE;
+
+public class RawUsbFunctionACM extends RawUsbFunctionInterface {
+    private int bmCapabilities;
+
+    public RawUsbFunctionACM(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_ACM_SUBTYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+
+        bmCapabilities = desc[3];
+    }
+
+    public String toString(){
+        String out = "      CDC ACM:\n";
+        out += String.format("        Capabilities:  %10s\n", "0x"+ Integer.toHexString(bmCapabilities));
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionCallMgmt.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionCallMgmt.java
@@ -1,0 +1,28 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_CALL_MGMT_SUBTYPE;
+
+public class RawUsbFunctionCallMgmt extends RawUsbFunctionInterface {
+    private byte bmCapabilities;
+    private int bDataInterface;
+
+    public RawUsbFunctionCallMgmt(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //if the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_CALL_MGMT_SUBTYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //if the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+
+        bmCapabilities = desc[3];
+        bDataInterface = desc[4];
+    }
+
+    public String toString(){
+        String out = "      CDC Call Management:\n";
+        out += String.format("        Capabilities:  %10s\n", "0x"+ Integer.toHexString(bmCapabilities));
+        out += String.format("        Data iFace Number:  %5d\n", bDataInterface);
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionEthernetNetworking.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionEthernetNetworking.java
@@ -1,0 +1,44 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_ETHERNET_SUBTYPE;
+
+public class RawUsbFunctionEthernetNetworking extends RawUsbFunctionInterface {
+    private int iMACAddress,bmEthernetStatistics,wMaxSegmentSize,
+                wNumberMCFilters,bNumberPowerFilters;
+    public RawUsbFunctionEthernetNetworking(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_ETHERNET_SUBTYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+
+        iMACAddress = byteToInt(desc[3]);
+        bmEthernetStatistics = fourBytesToInt(desc[7],desc[6],desc[5],desc[4]);
+        wMaxSegmentSize = bytesToInt(desc[9],desc[8]);
+        wNumberMCFilters = bytesToInt(desc[11],desc[10]);
+        bNumberPowerFilters = byteToInt(desc[12]);
+    }
+
+    public String toString(){
+        String out = "      CDC Ethernet:\n";
+
+        out += String.format("        iMACAddress:        %5d\n", iMACAddress);
+        out += String.format("        bmEthStats:    %10s\n", Integer.toBinaryString(bmEthernetStatistics));
+        out += String.format("        wMaxSegmentSize:    %5d\n", wMaxSegmentSize);
+        out += String.format("        wNumberMCFilters:   %5d\n", wNumberMCFilters);
+        out += String.format("        bNumberPowerFilters:%5d\n", bNumberPowerFilters);
+
+        return out;
+    }
+
+    private int fourBytesToInt(byte a, byte b, byte c, byte d){
+        short a2 = (short)(a&0xff);
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        short d2 = (short)(d&0xff);
+        return (a2 << 24) | (b2 << 16) | (c2 << 8) | d2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionHeader.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionHeader.java
@@ -1,0 +1,26 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_HEADER_SUBTYPE;
+
+public class RawUsbFunctionHeader extends RawUsbFunctionInterface {
+
+    private int bcdCDC;
+
+    public RawUsbFunctionHeader(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_HEADER_SUBTYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+
+        bcdCDC = bytesToInt(desc[4],desc[3]);
+    }
+
+    public String toString(){
+        String out = "      CDC Header:\n";
+        out += String.format("        Release Number:%10s\n", "0x"+ Integer.toHexString(bcdCDC));
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionInterface.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionInterface.java
@@ -1,0 +1,28 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_INTERFACE_TYPE;
+
+public abstract class RawUsbFunctionInterface {
+    protected int bFunctionLength,bDescriptorType,bDescriptorSubtype;
+
+    public RawUsbFunctionInterface(byte[] desc) throws DescriptorException{
+            bFunctionLength = byteToInt(desc[0]);
+            bDescriptorType = byteToInt(desc[1]);
+            bDescriptorSubtype= byteToInt(desc[2]);
+
+        //if the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != FUNCTION_INTERFACE_TYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //if the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+    }
+
+    protected int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+
+    protected int bytesToInt(byte b, byte c){
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        return (b2 << 8) | c2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionNCM.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionNCM.java
@@ -1,0 +1,24 @@
+package justin;
+
+import static justin.RawUsbManager.FUNCTION_NCM_SUBTYPE;
+
+public class RawUsbFunctionNCM extends RawUsbFunctionInterface {
+
+    public RawUsbFunctionNCM(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_NCM_SUBTYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+    }
+
+    public String toString(){
+        String out = "      CDC NCM:\n";
+        out += "        NCM data parsing is not yet available.\n";
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionUnion.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionUnion.java
@@ -1,0 +1,47 @@
+package justin;
+
+import java.util.ArrayList;
+
+import static justin.RawUsbManager.FUNCTION_UNION_SUBTYPE;
+
+public class RawUsbFunctionUnion extends RawUsbFunctionInterface {
+    private int bMasterInterface;
+    private ArrayList<Integer> bSlaveInterfaces;
+
+    public RawUsbFunctionUnion(byte[] desc) throws DescriptorException{
+        super(desc);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorSubtype != FUNCTION_UNION_SUBTYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bFunctionLength){throw new BadDescriptorException();}
+
+        bMasterInterface = desc[3];
+        bSlaveInterfaces = new ArrayList<Integer>();
+
+        for (int i = 4; i < bFunctionLength; i++){
+            bSlaveInterfaces.add(new Integer(desc[i]));
+        }
+    }
+
+    public int getMasterInterface(){
+        return bMasterInterface;
+    }
+
+    public int getSlaveInterface(int index){
+        return bSlaveInterfaces.get(index);
+    }
+
+    public String toString(){
+        String out = "      CDC Union:\n";
+        out += String.format("        Master Interface:   %5d\n", bMasterInterface);
+
+        for (int i = 0; i < bSlaveInterfaces.size(); i++){
+            out += String.format("        Slave Interface %d:  %5d\n",i,bSlaveInterfaces.get(i));
+        }
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionUnknown.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbFunctionUnknown.java
@@ -1,0 +1,18 @@
+package justin;
+
+public class RawUsbFunctionUnknown extends RawUsbFunctionInterface {
+
+    public RawUsbFunctionUnknown(byte[] desc) throws DescriptorException{
+        super(desc);
+    }
+
+    public String toString(){
+        String out = "      Unknown Functional Descriptor:\n";
+
+        out += String.format("        Length:             %5d\n",bFunctionLength);
+        out += String.format("        Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("        Subtype:            %5d\n",bDescriptorSubtype);
+
+        return out;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbInterface.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbInterface.java
@@ -1,0 +1,125 @@
+package justin;
+
+import java.util.ArrayList;
+
+import static justin.RawUsbManager.INTERFACE_TYPE;
+
+public class RawUsbInterface {
+    private int bLength, bDescriptorType, bInterfaceNumber, bAlternateSetting,
+                bNumEndpoints, bInterfaceClass, bInterfaceSubClass,
+                bInterfaceProtocol, iInterface;
+
+    private ArrayList<RawUsbFunctionInterface> functionalDescriptors;
+    private ArrayList<RawUsbEndpoint> endpoints;
+
+    //This is only here so RawUsbInterfaceAssociation can be a subclass of this
+    protected RawUsbInterface(){}
+
+    public RawUsbInterface(byte[] desc) throws DescriptorException {
+        //read the length of this descriptor as well as the descriptor type
+        bLength = byteToInt(desc[0]);
+        bDescriptorType = byteToInt(desc[1]);
+
+        //if the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != INTERFACE_TYPE){throw new IncorrectDescriptorException(bDescriptorType);}
+        //if the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bLength){throw new BadDescriptorException();}
+
+        //read the rest of the descriptor information
+        bInterfaceNumber = byteToInt(desc[2]);
+        bAlternateSetting = byteToInt(desc[3]);
+        bNumEndpoints = byteToInt(desc[4]);
+        bInterfaceClass = byteToInt(desc[5]);
+        bInterfaceSubClass = byteToInt(desc[6]);
+        bInterfaceProtocol = byteToInt(desc[7]);
+        iInterface = byteToInt(desc[8]);
+
+        functionalDescriptors = new ArrayList<RawUsbFunctionInterface>();
+        endpoints = new ArrayList<RawUsbEndpoint>();
+    }
+
+    public RawUsbEndpoint getEndpoint(int index){
+        return endpoints.get(index);
+    }
+
+    public int getEndpointCount(){
+        return endpoints.size();
+    }
+
+    public int getInterfaceClass(){
+        return bInterfaceClass;
+    }
+
+    public int getInterfaceSubclass(){
+        return bInterfaceSubClass;
+    }
+
+    public void addFunctionalDescriptor(RawUsbFunctionInterface f){
+        functionalDescriptors.add(f);
+    }
+
+    public int getFunctionalDescriptorCount(){
+        return functionalDescriptors.size();
+    }
+
+    public RawUsbFunctionInterface getFunctionalDescriptor(int index){
+        return functionalDescriptors.get(index);
+    }
+
+    public void addEndpoint(RawUsbEndpoint e){
+        endpoints.add(e);
+    }
+
+    public int getNumber(){
+        return bInterfaceNumber;
+    }
+
+    public String toString(){
+        String out = "    Interface Descriptor:\n";
+        String extra1 = "";
+        String extra2 = "";
+
+        switch (bInterfaceClass){
+            case 2:
+                extra1 = "  (Communications)";
+                break;
+            case 10:
+                extra1 = "  (CDC Data)";
+                break;
+        }
+        if (bInterfaceClass == 2){
+            switch (bInterfaceSubClass){
+                case 2:
+                    extra2 = "  (Abstract Control Model)";
+                    break;
+                case 13:
+                    extra2 = "  (Network Control Model)";
+                    break;
+            }
+        }
+
+        out += String.format("      Length:             %5d\n",bLength);
+        out += String.format("      Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("      Interface Number:   %5d\n",bInterfaceNumber);
+        out += String.format("      Alternate Setting:  %5d\n",bAlternateSetting);
+        out += String.format("      Number of Endpoints:%5d\n",bNumEndpoints);
+        out += String.format("      Interface Class:    %5d\n",bInterfaceClass,extra1);
+        out += String.format("      Interface Subclass: %5d\n",bInterfaceSubClass,extra2);
+        out += String.format("      Protocol:           %5d\n",bInterfaceProtocol);
+        out += String.format("      String Index:       %5d\n",iInterface);
+
+        for (RawUsbFunctionInterface f : functionalDescriptors){
+            out += f.toString();
+        }
+
+        for (RawUsbEndpoint e : endpoints){
+            out += e.toString();
+        }
+
+        return out;
+    }
+
+    private int byteToInt(byte b) {
+        return (int) b & 0xff;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbInterfaceAssociation.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbInterfaceAssociation.java
@@ -1,0 +1,45 @@
+package justin;
+
+import static justin.RawUsbManager.INTERFACE_ASSOCIATION_TYPE;
+
+public class RawUsbInterfaceAssociation extends RawUsbInterface {
+    private int bLength,bDescriptorType,bFirstInterface,bInterfaceCount,
+                bFunctionClass,bFunctionSubClass,bFunctionProtocol,iFunction;
+
+    public RawUsbInterfaceAssociation(byte[] desc) throws DescriptorException{
+        bLength = byteToInt(desc[0]);
+        bDescriptorType = byteToInt(desc[1]);
+
+        //If the type isn't correct, this was given the wrong descriptor.
+        if (bDescriptorType != INTERFACE_ASSOCIATION_TYPE){
+            throw new IncorrectDescriptorException(bDescriptorType);
+        }
+        //If the length of the descriptor is less than what's expected, the descriptor is bad
+        if (desc.length < bLength){throw new BadDescriptorException();}
+        bFirstInterface = byteToInt(desc[2]);
+        bInterfaceCount = byteToInt(desc[3]);
+        bFunctionClass = byteToInt(desc[4]);
+        bFunctionSubClass = byteToInt(desc[5]);
+        bFunctionProtocol = byteToInt(desc[6]);
+        iFunction = byteToInt(desc[7]);
+    }
+
+    public String toString(){
+        String out = "    Interface Association:\n";
+
+        out += String.format("      Length:             %5d\n",bLength);
+        out += String.format("      Descriptor Type:    %5d\n",bDescriptorType);
+        out += String.format("      First Interface:    %5d\n",bFirstInterface);
+        out += String.format("      Interface Count:    %5d\n",bInterfaceCount);
+        out += String.format("      Function Class:     %5d\n",bFunctionClass);
+        out += String.format("      Function Subclass:  %5d\n",bFunctionSubClass);
+        out += String.format("      Protocol:           %5d\n",bFunctionProtocol);
+        out += String.format("      Function Index:     %5d\n",iFunction);
+
+        return out;
+    }
+
+    private int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbManager.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbManager.java
@@ -1,0 +1,178 @@
+package justin;
+
+import android.util.Log;
+
+import java.util.Arrays;
+
+public class RawUsbManager {
+    public static final int DEVICE_TYPE = 1;
+    public static final int CONFIGURATION_TYPE = 2;
+    public static final int INTERFACE_TYPE = 4;
+    public static final int ENDPOINT_TYPE = 5;
+    public static final int INTERFACE_ASSOCIATION_TYPE = 11;
+
+    public static final int FUNCTION_INTERFACE_TYPE = 36;
+
+    public static final int FUNCTION_HEADER_SUBTYPE = 0;
+    public static final int FUNCTION_CALL_MGMT_SUBTYPE = 1;
+    public static final int FUNCTION_ACM_SUBTYPE = 2;
+    public static final int FUNCTION_UNION_SUBTYPE = 6;
+    public static final int FUNCTION_ETHERNET_SUBTYPE = 15;
+    public static final int FUNCTION_NCM_SUBTYPE = 26;
+
+    public static String TAG = "com.justin.RawUsbManager";
+
+    public static RawUsbDevice getDeviceFromRawString(byte[] desc){
+        int dLength, dType, absOffset;
+        absOffset = 0;
+
+        RawUsbDevice tempDevice = null;
+
+        //Outside loop reads entire device descriptor
+        while (absOffset < desc.length){
+            dLength = byteToInt(desc[0]);
+            dType = byteToInt(desc[1]);
+
+            //We only want to build the device if this is a device descriptor.
+            if (dType == 1){
+                try{
+                    //Build the device from the descriptor. If this throws an exception then
+                    //we will just return null since we can't read in the device.
+                    tempDevice = new RawUsbDevice(
+                            Arrays.copyOfRange(desc,absOffset,absOffset+dLength));
+                } catch (DescriptorException e){
+                    return null;
+                }
+
+                absOffset += dLength;
+
+                //This line parses all of the device's configurations
+                absOffset = buildConfigs(tempDevice,desc,absOffset);
+            }
+        }
+
+        return tempDevice;
+    }
+
+    private static int buildConfigs(RawUsbDevice tempDevice, byte[] desc, int absOffset){
+        RawUsbConfiguration tempConfig;
+
+        int cLength = desc[absOffset];
+
+        int numConfigs = tempDevice.getConfigurationCount();
+
+        for (int i = 0; i < numConfigs; i++){
+            try{
+                //Creates configuration object
+                tempConfig = new RawUsbConfiguration(
+                        Arrays.copyOfRange(desc,absOffset,absOffset+cLength));
+                //Parses full configuration and builds interfaces/endpoints/etc.
+                buildConfig(tempConfig,
+                        Arrays.copyOfRange(desc,absOffset,
+                                absOffset+tempConfig.getTotalLength()));
+                tempDevice.addConfiguration(tempConfig);
+
+                absOffset += tempConfig.getTotalLength();
+            } catch (DescriptorException e){
+                //If we get a descriptor exception, adding cLength allows us to
+                //keep reading until we find another configuration descriptor.
+                absOffset += cLength;
+            }
+
+        }
+
+        return absOffset;
+    }
+
+    private static void buildConfig(RawUsbConfiguration tempConfig, byte[] desc){
+        RawUsbInterface tempInterface = null;
+        RawUsbFunctionInterface tempFD;
+        RawUsbEndpoint tempEndpoint;
+
+        int intLength, intType;
+        int total = tempConfig.getTotalLength();
+        int offset = tempConfig.getLength();
+
+        while (offset < total){
+            intLength = desc[offset];
+            intType = desc[offset+1];
+
+            try {
+                if (intType == INTERFACE_TYPE){ //Construct Interface
+                    Log.d(TAG,"Found an interface");
+                    tempInterface = new RawUsbInterface(
+                            Arrays.copyOfRange(desc,offset,offset+intLength));
+                    tempConfig.addInterface(tempInterface);
+
+                } else if (intType == FUNCTION_INTERFACE_TYPE){
+                    //Construct functional interface
+                    tempFD = parseFunctionalDescriptor(desc,offset,intLength);
+                    //doesn't check if tempInterface is null, fix later
+                    tempInterface.addFunctionalDescriptor(tempFD);
+
+                } else if (intType == ENDPOINT_TYPE){
+                    tempEndpoint = new RawUsbEndpoint(
+                            Arrays.copyOfRange(desc,offset,offset+intLength));
+                    tempInterface.addEndpoint(tempEndpoint);
+
+                } else if (intType == INTERFACE_ASSOCIATION_TYPE){
+                    tempInterface = new RawUsbInterfaceAssociation(
+                            Arrays.copyOfRange(desc,offset,offset+intLength));
+                    tempConfig.addInterface(tempInterface);
+
+                } else {
+                    tempConfig.addOther(new RawUsbOtherDescriptor(
+                            Arrays.copyOfRange(desc,offset,offset+intLength)));
+                }
+            } catch (DescriptorException e){
+                //TODO add exception handling. Maybe return null?
+                Log.d(TAG,"Uh oh, descriptor exception");
+            }
+
+            offset += intLength;
+        }
+    }
+
+    private static RawUsbFunctionInterface parseFunctionalDescriptor(byte[] desc, int offset, int intLength)
+            throws DescriptorException{
+
+        RawUsbFunctionInterface tempFD;
+
+        int functionSubtype = desc[offset+2];
+
+        if (functionSubtype == FUNCTION_HEADER_SUBTYPE){
+            tempFD = new RawUsbFunctionHeader(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else if (functionSubtype == FUNCTION_CALL_MGMT_SUBTYPE){
+            tempFD = new RawUsbFunctionCallMgmt(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else if (functionSubtype == FUNCTION_ACM_SUBTYPE){
+            tempFD = new RawUsbFunctionACM(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else if (functionSubtype == FUNCTION_UNION_SUBTYPE){
+            tempFD = new RawUsbFunctionUnion(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else if (functionSubtype == FUNCTION_ETHERNET_SUBTYPE){
+            tempFD = new RawUsbFunctionEthernetNetworking(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else if (functionSubtype == FUNCTION_NCM_SUBTYPE){
+            tempFD = new RawUsbFunctionNCM(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        } else {
+            tempFD = new RawUsbFunctionUnknown(
+                    Arrays.copyOfRange(desc,offset,offset+intLength));
+        }
+
+        return tempFD;
+    }
+
+    private static int byteToInt(byte b){
+        return (int) b & 0xff;
+    }
+
+    private static int bytesToInt(byte b, byte c){
+        short b2 = (short)(b&0xff);
+        short c2 = (short)(c&0xff);
+        return (b2 << 8) | c2;
+    }
+}

--- a/usbSerialForAndroid/src/main/java/com/justin/RawUsbOtherDescriptor.java
+++ b/usbSerialForAndroid/src/main/java/com/justin/RawUsbOtherDescriptor.java
@@ -1,0 +1,25 @@
+package justin;
+
+public class RawUsbOtherDescriptor {
+    private int length,type;
+    private byte[] descriptor;
+
+    public RawUsbOtherDescriptor(byte[] desc){
+        length = desc[0];
+        type = desc[1];
+        descriptor = desc;
+    }
+
+    public byte[] getRawDescriptor(){
+        return descriptor;
+    }
+
+    public String toString(){
+        String out = "Unknown Descriptor:\n";
+
+        out += String.format("Length:             %5d\n",length);
+        out += String.format("Descriptor Type:    %5d\n",type);
+
+        return out;
+    }
+}


### PR DESCRIPTION
The new "RawUsb" library builds up descriptor objects from the raw usb descriptors. These prove to have some functionality that the Android OS does not provide on its own. For example, this allows for the parsing of several interface functional descriptors which are normally inaccessible.

The updated cdc-acm driver allows for several "virtual" ports on a single device. If you have descriptors set up for more than one serial port on your usb device, the new driver allows you to pick one of them to read from. It detects interfaces that are bound together with a union and it also looks for collapsed interfaces.