### PR TITLE
Expose a isOpen method to check on the current state of the connection

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -221,6 +221,10 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         return offset;
     }
 
+    @Override
+    public boolean isOpen() {
+        return mConnection != null;
+    }
 
     @Override
     public abstract void setParameters(int baudRate, int dataBits, int stopBits, int parity) throws IOException;

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
@@ -226,4 +226,9 @@ public interface UsbSerialPort extends Closeable {
      */
     public boolean purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException;
 
+    /**
+     * @return the current state of the connection
+     */
+    public boolean isOpen();
+
 }


### PR DESCRIPTION
Since UsbDeviceConnection is non null when open, this makes it easier to detect if we have a active connection or not.