### PR TITLE
Debug mode disable

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 public class SerialInputOutputManager implements Runnable {
 
     private static final String TAG = SerialInputOutputManager.class.getSimpleName();
-    private static final boolean DEBUG = true;
+    public static boolean DEBUG = false;
     private static final int BUFSIZ = 4096;
 
     /**


### PR DESCRIPTION
Ability to disable DEBUG Logging for in/out bytes.
With enabled logging every byte, library spams too much.