### PR TITLE
Use monotonic clock for timeouts

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -12,6 +12,8 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
 import android.util.Log;
 
+import com.hoho.android.usbserial.util.MonotonicClock;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -146,11 +148,11 @@ public class FtdiSerialDriver implements UsbSerialDriver {
             }
             int nread;
             if (timeout != 0) {
-                long endTime = System.currentTimeMillis() + timeout;
+                long endTime = MonotonicClock.millis() + timeout;
                 do {
-                    nread = super.read(dest, Math.max(1, (int)(endTime - System.currentTimeMillis())), false);
-                } while (nread == READ_HEADER_LENGTH && System.currentTimeMillis() < endTime);
-                if(nread <= 0 && System.currentTimeMillis() < endTime)
+                    nread = super.read(dest, Math.max(1, (int)(endTime - MonotonicClock.millis())), false);
+                } while (nread == READ_HEADER_LENGTH && MonotonicClock.millis() < endTime);
+                if(nread <= 0 && MonotonicClock.millis() < endTime)
                     testConnection();
             } else {
                 do {

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -17,6 +17,7 @@ import android.hardware.usb.UsbInterface;
 import android.util.Log;
 
 import com.hoho.android.usbserial.BuildConfig;
+import com.hoho.android.usbserial.util.MonotonicClock;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -174,9 +175,9 @@ public class ProlificSerialDriver implements UsbSerialDriver {
             try {
                 while (!mStopReadStatusThread) {
                     byte[] buffer = new byte[STATUS_BUFFER_SIZE];
-                    long endTime = System.currentTimeMillis() + 500;
+                    long endTime = MonotonicClock.millis() + 500;
                     int readBytesCount = mConnection.bulkTransfer(mInterruptEndpoint, buffer, STATUS_BUFFER_SIZE, 500);
-                    if(readBytesCount == -1 && System.currentTimeMillis() < endTime)
+                    if(readBytesCount == -1 && MonotonicClock.millis() < endTime)
                         testConnection();
                     if (readBytesCount > 0) {
                         if (readBytesCount != STATUS_BUFFER_SIZE) {

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/MonotonicClock.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/MonotonicClock.java
@@ -1,0 +1,14 @@
+package com.hoho.android.usbserial.util;
+
+public final class MonotonicClock {
+
+    private static final long NS_PER_MS = 1_000_000;
+
+    private MonotonicClock() {
+    }
+
+    public static long millis() {
+        return System.nanoTime() / NS_PER_MS;
+    }
+
+}


### PR DESCRIPTION
First of all, thank you very much for this great library!

**Problem addressed:** The existing code is using `System.currentTimeMillis()` for timeout calculations. However, this method is not guaranteed to be monotonic: it might jump backwards/forwards based on user settings and NTP. Therefore, timeouts might be much longer or shorter than intended.

**Solution:** The method `System.nanoTime()` is guaranteed to be monotonic. Therefore I wrapped it in a static method that can be used as a drop-in replacement in the existing code (minimising changes).

**Test plan:** I tested the changes using a FT232RL on Android 6.0.1 and was able to write/read as expected.