### PR TITLE
Add support for STM Virtual COM Port

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -317,6 +317,10 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                 new int[] {
                     UsbId.ARM_MBED,
                 });
+        supportedDevices.put(UsbId.VENDOR_STM,
+                new int[] {
+                        UsbId.STM_VIRTUAL_COM_PORT,
+                });
         return supportedDevices;
     }
 

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
@@ -60,6 +60,9 @@ public final class UsbId {
     public static final int VENDOR_ARM = 0x0d28;
     public static final int ARM_MBED = 0x0204;
 
+    public static final int VENDOR_STM = 0x0483;
+    public static final int STM_VIRTUAL_COM_PORT = 0x5740;
+
     private UsbId() {
         throw new IllegalAccessError("Non-instantiable class");
     }


### PR DESCRIPTION
Adding support for the STM Virtual COM Port

https://the-sz.com/products/usbid/index.php?v=0x0483&p=0x5740

This is the default VID/PID associated with the virtual COM port feature of microcontrollers from STMicroelectronics, notably the STM32F4xx series which is widely found in hobbyist ARM-based projects.

I have successfully connected an STM32F4xx microcontroller to an Android project, verifying that it does indeed work correctly with the existing CdcAcm serial driver using a custom probing table:
        customTable.addProduct(0x0483, 0x5740, CdcAcmSerialDriver::class.java)

