### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ allprojects {
 Add library to dependencies
 ```gradle
 dependencies {
-    implementation 'com.github.mik3y:usb-serial-for-android:3.3.1'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.4.0'
 }
 ```
 


### PR DESCRIPTION
`usbIoManager.start(); `

It doesn't work in 3.3.1 .