### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,16 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11.0.3, 11 ]
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.11
+    - name: set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Build with Gradle
       run: ./gradlew assembleDebug


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.
Also added are fixed (major) release version(s) such as 11.0.3. This is often a good practice whenever a build/test triggers (push/pull events) this can determine if the latest JDK (11) had failed the build vs something in your code that caused it. For example, when building with JDK 11.0.3 (fixed version) the build passes (green) and JDK 11 fails (red) will mean that the latest JDK (11) was the cause and not your code.   Note: Other distributions such as Temurin don’t support archived fixed release prior to Sept. 2021.

Signed-off-by: Carl Dea <carldea@gmail.com>