### PR TITLE
added VID/PID for Qinheng CH9102F

### DIFF
--- a/usbSerialExamples/src/main/res/xml/device_filter.xml
+++ b/usbSerialExamples/src/main/res/xml/device_filter.xml
@@ -34,4 +34,5 @@
     <usb-device vendor-id="1155" product-id="22336" /><!-- 0x0483 / 0x5740: ST CDC -->
     <usb-device vendor-id="11914" product-id="5"   /> <!-- 0x2E8A / 0x0005: Raspberry Pi Pico Micropython -->
     <usb-device vendor-id="11914" product-id="10"  /> <!-- 0x2E8A / 0x000A: Raspberry Pi Pico SDK -->
+    <usb-device vendor-id="6790" product-id="21972" /><!-- 0x1A86 / 0x55D4: Qinheng CH9102F -->
 </resources>

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -326,6 +326,10 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                         UsbId.RASPBERRY_PI_PICO_MICROPYTHON,
                         UsbId.RASPBERRY_PI_PICO_SDK,
                 });
+        supportedDevices.put(UsbId.VENDOR_QINHENG,
+                new int[] {
+                        UsbId.QINHENG_CH9102F,
+                });
         return supportedDevices;
     }
 

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbId.java
@@ -61,6 +61,7 @@ public final class UsbId {
     public static final int VENDOR_QINHENG = 0x1a86;
     public static final int QINHENG_CH340 = 0x7523;
     public static final int QINHENG_CH341A = 0x5523;
+    public static final int QINHENG_CH9102F = 0x55D4;
 
     // at www.linux-usb.org/usb.ids listed for NXP/LPC1768, but all processors supported by ARM mbed DAPLink firmware report these ids
     public static final int VENDOR_ARM = 0x0d28;


### PR DESCRIPTION
One of Qinheng's newer parts (CH9102F) follows the CDC standard (in contrast to some of their other offerings).  This PR just adds it to the list.
