### PR TITLE
Update CommonUsbSerialPort.java

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -173,6 +173,9 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         if(mConnection == null) {
             throw new IOException("Connection closed");
         }
+        if (mUsbRequest == null) {
+            throw new IOException("USB request is null");
+        }
         if(dest.length <= 0) {
             throw new IllegalArgumentException("Read buffer to small");
         }


### PR DESCRIPTION
Fixed a bug where mUsbRequest can be null due to port being closed before SerialInputOutputManager is stopped. So calling queue on a null object create an error: 

08-22 19:06:40.111 D/UsbDeviceConnectionJNI( 7787): close
08-22 19:06:40.112 I/SerialInputOutputManager( 7787): Stop requested
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): Run ending due to exception: Attempt to invoke virtual method 'boolean android.hardware.usb.UsbRequest.queue(java.nio.ByteBuffer, int)' on a null object reference
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.hardware.usb.UsbRequest.queue(java.nio.ByteBuffer, int)' on a null object reference
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): 	at com.hoho.android.usbserial.driver.CommonUsbSerialPort.read(CommonUsbSerialPort.java:199)
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): 	at com.hoho.android.usbserial.driver.CommonUsbSerialPort.read(CommonUsbSerialPort.java:169)
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): 	at com.hoho.android.usbserial.util.SerialInputOutputManager.step(SerialInputOutputManager.java:225)
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): 	at com.hoho.android.usbserial.util.SerialInputOutputManager.run(SerialInputOutputManager.java:203)
08-22 19:06:40.112 W/SerialInputOutputManager( 7787): 	at java.lang.Thread.run(Thread.java:923)