### PR TITLE
Issue 533 - fix: remove length parameter from call to UsbRequest.queue

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -206,7 +206,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
 
         } else {
             final ByteBuffer buf = ByteBuffer.wrap(dest, 0, length);
-            if (!mUsbRequest.queue(buf, length)) {
+            if (!mUsbRequest.queue(buf)) {
                 throw new IOException("Queueing USB request failed");
             }
             final UsbRequest response = mConnection.requestWait();


### PR DESCRIPTION
See linked issue: https://github.com/mik3y/usb-serial-for-android/issues/553