### PR TITLE
Refactor USB Communication: Implement Multiple Buffers, Separate Threads, and Remove Read TimeoutsMulti buff read

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -354,4 +354,9 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
     @Override
     public void setBreak(boolean value) throws IOException { throw new UnsupportedOperationException(); }
 
+    @Override
+    public UsbDeviceConnection getConnection() {
+        return mConnection;
+    }
+
 }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialPort.java
@@ -321,4 +321,8 @@ public interface UsbSerialPort extends Closeable {
      */
     boolean isOpen();
 
+    /**
+     * Returns the underlying {@link UsbDeviceConnection}.
+     */
+    UsbDeviceConnection getConnection();
 }

--- a/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/util/SerialInputOutputManagerTest.java
+++ b/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/util/SerialInputOutputManagerTest.java
@@ -4,15 +4,22 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.ByteBuffer;
+
+import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbRequest;
 import android.os.Process;
 
 import com.hoho.android.usbserial.driver.CommonUsbSerialPort;
 
 import org.junit.Test;
+import org.mockito.Mock;
 
 public class SerialInputOutputManagerTest {
 
+    @Mock
+    private UsbRequest mRequest;
 
     // catch all Throwables in onNewData() and onRunError()
     @Test
@@ -29,23 +36,28 @@ public class SerialInputOutputManagerTest {
             @Override public void onRunError(Exception e) { this.e = e; throw new UnknownError("error2");}
         }
 
+        UsbRequest request = mock(UsbRequest.class);
         UsbEndpoint readEndpoint = mock(UsbEndpoint.class);
+        UsbDeviceConnection connection = mock(UsbDeviceConnection.class);
         when(readEndpoint.getMaxPacketSize()).thenReturn(16);
         CommonUsbSerialPort port = mock(CommonUsbSerialPort.class);
         when(port.getReadEndpoint()).thenReturn(readEndpoint);
-        when(port.read(new byte[16], 0)).thenReturn(1);
+        when(port.getConnection()).thenReturn(connection);
+        when(connection.requestWait()).thenReturn(request);
+        when(request.getClientData()).thenReturn(ByteBuffer.wrap(new byte[16]).put((byte) 0x00));
         SerialInputOutputManager manager = new SerialInputOutputManager(port);
         manager.setThreadPriority(Process.THREAD_PRIORITY_DEFAULT);
+        manager.setRequestSupplier(() -> request);
 
         ExceptionListener exceptionListener = new ExceptionListener();
         manager.setListener(exceptionListener);
-        manager.run();
+        manager.runRead();
         assertEquals(RuntimeException.class, exceptionListener.e.getClass());
         assertEquals("exception1", exceptionListener.e.getMessage());
 
         ErrorListener errorListener = new ErrorListener();
         manager.setListener(errorListener);
-        manager.run();
+        manager.runRead();
         assertEquals(Exception.class, errorListener.e.getClass());
         assertEquals("java.lang.UnknownError: error1", errorListener.e.getMessage());
         assertEquals(UnknownError.class, errorListener.e.getCause().getClass());


### PR DESCRIPTION
Refactored `SerialInputOutputManager`:
 
- Implemented multiple read buffers to improve USB reading efficiency and reduce latency.
- Used separate threads for reading and writing, enhancing concurrency and performance.
- Removed read timeouts, as they are not necessary for event-driven data reading.

These changes enhance the responsiveness, reliability, and robustness of USB communication.