### PR TITLE
Fix thread safety, races, and correctness issues across drivers

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -34,7 +34,7 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
 
     public static final int USB_SUBCLASS_ACM = 2;
 
-    private final String TAG = CdcAcmSerialDriver.class.getSimpleName();
+    private static final String TAG = CdcAcmSerialDriver.class.getSimpleName();
 
     private final UsbDevice mDevice;
     private final List<UsbSerialPort> mPorts;
@@ -88,8 +88,8 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
 
         private int mControlIndex;
 
-        private boolean mRts = false;
-        private boolean mDtr = false;
+        private volatile boolean mRts = false;
+        private volatile boolean mDtr = false;
 
         private static final int USB_RECIP_INTERFACE = 0x01;
         private static final int USB_RT_ACM = UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
@@ -200,6 +200,9 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             if (!mConnection.claimInterface(mControlInterface, true)) {
                 throw new IOException("Could not claim control interface");
             }
+            if (mControlInterface.getEndpointCount() == 0) {
+                throw new IOException("No endpoint on control interface");
+            }
             mControlEndpoint = mControlInterface.getEndpoint(0);
             if (mControlEndpoint.getDirection() != UsbConstants.USB_DIR_IN || mControlEndpoint.getType() != UsbConstants.USB_ENDPOINT_XFER_INT) {
                 throw new IOException("Invalid control endpoint");
@@ -264,8 +267,12 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
         protected void closeInt() {
             try {
                 mConnection.releaseInterface(mControlInterface);
-                mConnection.releaseInterface(mDataInterface);
-            } catch(Exception ignored) {}
+                if (mDataInterface != mControlInterface) {
+                    mConnection.releaseInterface(mDataInterface);
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interfaces", e);
+            }
         }
 
         @Override

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
@@ -64,10 +64,10 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
         private static final int USB_TIMEOUT_MILLIS = 5000;
 
-        private final int DEFAULT_BAUD_RATE = 9600;
+        private static final int DEFAULT_BAUD_RATE = 9600;
 
-        private boolean dtr = false;
-        private boolean rts = false;
+        private volatile boolean dtr = false;
+        private volatile boolean rts = false;
 
         public Ch340SerialPort(UsbDevice device, int portNumber) {
             super(device, portNumber);
@@ -108,7 +108,9 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
             try {
                 for (int i = 0; i < mDevice.getInterfaceCount(); i++)
                     mConnection.releaseInterface(mDevice.getInterface(i));
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interfaces", e);
+            }
         }
 
         private int controlOut(int request, int value, int index) {
@@ -158,8 +160,8 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
         private byte getStatus() throws IOException {
             byte[] buffer = new byte[2];
             int ret = controlIn(0x95, 0x0706, 0, buffer);
-            if (ret < 0)
-                throw new IOException("Error getting control lines");
+            if (ret != buffer.length)
+                throw new IOException("Error getting control lines, expected " + buffer.length + " bytes, got " + ret);
             return buffer[0];
         }
 

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ChromeCcdSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ChromeCcdSerialDriver.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 
 public class ChromeCcdSerialDriver implements UsbSerialDriver{
 
-    private final String TAG = ChromeCcdSerialDriver.class.getSimpleName();
+    private static final String TAG = ChromeCcdSerialDriver.class.getSimpleName();
 
     private final UsbDevice mDevice;
     private final List<UsbSerialPort> mPorts;
@@ -34,7 +34,7 @@ public class ChromeCcdSerialDriver implements UsbSerialDriver{
     public ChromeCcdSerialDriver(UsbDevice mDevice) {
         this.mDevice = mDevice;
         mPorts = new ArrayList<UsbSerialPort>();
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < mDevice.getInterfaceCount(); i++)
             mPorts.add(new ChromeCcdSerialPort(mDevice, i));
     }
 
@@ -67,7 +67,9 @@ public class ChromeCcdSerialDriver implements UsbSerialDriver{
         protected void closeInt() {
             try {
                 mConnection.releaseInterface(mDataInterface);
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interface", e);
+            }
         }
 
         @Override

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CommonUsbSerialPort.java
@@ -18,8 +18,9 @@ import com.hoho.android.usbserial.util.UsbUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Objects;
  */
 public abstract class CommonUsbSerialPort implements UsbSerialPort {
 
-    public static boolean DEBUG = false;
+    public static volatile boolean DEBUG = false;
 
     private static final String TAG = CommonUsbSerialPort.class.getSimpleName();
     private static final int MAX_READ_SIZE = 16 * 1024; // = old bulkTransfer limit prior to Android 9
@@ -41,8 +42,8 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
     protected UsbDeviceConnection mConnection;
     protected UsbEndpoint mReadEndpoint;
     protected UsbEndpoint mWriteEndpoint;
-    protected UsbRequest mReadRequest;
-    protected LinkedList<UsbRequest> mReadQueueRequests;
+    protected volatile UsbRequest mReadRequest;
+    protected List<UsbRequest> mReadQueueRequests;
     private int mReadQueueBufferCount;
     private int mReadQueueBufferSize;
     protected FlowControl mFlowControl = FlowControl.NONE;
@@ -91,6 +92,9 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
      */
     @Override
     public String getSerial() {
+        if (mConnection == null) {
+            throw new IllegalStateException("Port not open");
+        }
         return mConnection.getSerial();
     }
 
@@ -140,7 +144,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
             }
             if (bufferCount > 0) {
                 if (mReadQueueRequests == null) {
-                    mReadQueueRequests = new LinkedList<>();
+                    mReadQueueRequests = new ArrayList<>();
                 }
                 for (int i = mReadQueueRequests.size(); i < bufferCount; i++) {
                     ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
@@ -186,7 +190,9 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
             if (!ok) {
                 try {
                     close();
-                } catch (Exception ignored) {}
+                } catch (Exception e) {
+                    Log.w(TAG, "Error closing port after failed open", e);
+                }
             }
         }
     }
@@ -200,24 +206,40 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         }
         UsbRequest readRequest = mReadRequest;
         mReadRequest = null;
-        try {
-            readRequest.cancel();
-        } catch(Exception ignored) {}
+        closeUsbRequest(readRequest);
         if(mReadQueueRequests != null) {
             for(UsbRequest readQueueRequest : mReadQueueRequests) {
-                try {
-                    readQueueRequest.cancel();
-                } catch(Exception ignored) {}
+                closeUsbRequest(readQueueRequest);
             }
             mReadQueueRequests = null;
         }
         try {
             closeInt();
-        } catch(Exception ignored) {}
+        } catch(Exception e) {
+            Log.w(TAG, "Error during driver close", e);
+        }
         try {
             mConnection.close();
-        } catch(Exception ignored) {}
+        } catch(Exception e) {
+            Log.w(TAG, "Error closing USB connection", e);
+        }
         mConnection = null;
+    }
+
+    private void closeUsbRequest(UsbRequest request) {
+        if (request == null) return;
+        try {
+            request.cancel();
+        } catch (Exception e) {
+            Log.w(TAG, "Error cancelling USB request", e);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            try {
+                request.close();
+            } catch (Exception e) {
+                Log.w(TAG, "Error closing USB request", e);
+            }
+        }
     }
 
     protected abstract void closeInt();
@@ -239,7 +261,7 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         byte[] buf = new byte[2];
         int len = mConnection.controlTransfer(0x80 /*DEVICE*/, 0 /*GET_STATUS*/, 0, 0, buf, buf.length, 200);
         if(len < 0)
-            throw new IOException(msg);
+            throw new IOException(msg + ", rc=" + len);
     }
 
     @Override
@@ -261,58 +283,67 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
         length = Math.min(length, dest.length);
         final int nread;
         if (timeout != 0) {
-            if(useReadQueue()) {
-                throw new IllegalStateException("Cannot use timeout!=0 if readQueue is enabled");
-            }
-            // bulkTransfer will cause data loss with short timeout + high baud rates + continuous transfer
-            //   https://stackoverflow.com/questions/9108548/android-usb-host-bulktransfer-is-losing-data
-            // but mConnection.requestWait(timeout) available since Android 8.0 es even worse,
-            // as it crashes with short timeout, e.g.
-            //   A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x276a in tid 29846 (pool-2-thread-1), pid 29618 (.usbserial.test)
-            //     /system/lib64/libusbhost.so (usb_request_wait+192)
-            //     /system/lib64/libandroid_runtime.so (android_hardware_UsbDeviceConnection_request_wait(_JNIEnv*, _jobject*, long)+84)
-            // data loss / crashes were observed with timeout up to 200 msec
-            long endTime = testConnection ? MonotonicClock.millis() + timeout : 0;
-            int readMax = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) ? length : Math.min(length, MAX_READ_SIZE);
-            nread = mConnection.bulkTransfer(mReadEndpoint, dest, readMax, timeout);
-            // Android error propagation is improvable:
-            //  nread == -1 can be: timeout, connection lost, buffer to small, ???
-            if(nread == -1 && testConnection)
-                testConnection(MonotonicClock.millis() < endTime);
-
+            nread = readBulk(dest, length, timeout, testConnection);
         } else {
-            ByteBuffer buf = null;
-            if(useReadQueue()) {
-                if (length != mReadQueueBufferSize) {
-                    throw new IllegalStateException("Cannot use different length if readQueue is enabled");
-                }
-            } else {
-                buf = ByteBuffer.wrap(dest, 0, length);
-                if (!mReadRequest.queue(buf, length)) {
-                    throw new IOException("Queueing USB request failed");
-                }
+            nread = readAsync(dest, length);
+        }
+        return Math.max(nread, 0);
+    }
+
+    private int readBulk(byte[] dest, int length, int timeout, boolean testConnection) throws IOException {
+        if(useReadQueue()) {
+            throw new IllegalStateException("Cannot use timeout!=0 if readQueue is enabled");
+        }
+        // bulkTransfer will cause data loss with short timeout + high baud rates + continuous transfer
+        //   https://stackoverflow.com/questions/9108548/android-usb-host-bulktransfer-is-losing-data
+        // mConnection.requestWait(timeout) available since Android 8.0 is even worse,
+        // as it crashes with short timeout. Data loss/crashes observed with timeout up to 200 msec.
+        long endTime = testConnection ? MonotonicClock.millis() + timeout : 0;
+        int readMax = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) ? length : Math.min(length, MAX_READ_SIZE);
+        int nread = mConnection.bulkTransfer(mReadEndpoint, dest, readMax, timeout);
+        if(nread == -1 && testConnection)
+            testConnection(MonotonicClock.millis() < endTime);
+        return nread;
+    }
+
+    private int readAsync(byte[] dest, int length) throws IOException {
+        ByteBuffer buf = null;
+        UsbRequest request = mReadRequest;
+        if(useReadQueue()) {
+            if (length != mReadQueueBufferSize) {
+                throw new IllegalStateException("Cannot use different length if readQueue is enabled");
             }
-            final UsbRequest response = mConnection.requestWait();
-            if (response == null) {
-                throw new IOException("Waiting for USB request failed");
+        } else {
+            if (request == null) {
+                throw new IOException("Connection closed");
             }
-            if(useReadQueue()) {
-                buf = (ByteBuffer) response.getClientData();
-                System.arraycopy(buf.array(), 0, dest, 0, buf.position());
-                if(mReadRequest != null) { // re-queue if connection not closed
+            buf = ByteBuffer.wrap(dest, 0, length);
+            if (!request.queue(buf, length)) {
+                throw new IOException("Queueing USB request failed");
+            }
+        }
+        final UsbRequest response = mConnection.requestWait();
+        if (response == null) {
+            throw new IOException("Waiting for USB request failed");
+        }
+        if(useReadQueue()) {
+            buf = (ByteBuffer) response.getClientData();
+            System.arraycopy(buf.array(), 0, dest, 0, buf.position());
+            if(mReadRequest != null) {
+                try {
                     if (!response.queue(buf, buf.capacity())) {
                         throw new IOException("Queueing USB request failed");
                     }
+                } catch (Exception e) {
+                    if (mReadRequest != null) throw e;
                 }
             }
-            nread = Objects.requireNonNull(buf).position();
-            // Android error propagation is improvable:
-            //   response != null & nread == 0 can be: connection lost, buffer to small, ???
-            if(nread == 0) {
-                testConnection(true);
-            }
         }
-        return Math.max(nread, 0);
+        int nread = Objects.requireNonNull(buf).position();
+        if(nread == 0) {
+            testConnection(true);
+        }
+        return nread;
     }
 
     @Override
@@ -329,10 +360,9 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
             int requestTimeout;
             final int requestLength;
             final int actualLength;
+            final byte[] writeBuffer;
 
             synchronized (mWriteBufferLock) {
-                final byte[] writeBuffer;
-
                 if (mWriteBuffer == null) {
                     mWriteBuffer = new byte[mWriteEndpoint.getMaxPacketSize()];
                 }
@@ -340,22 +370,21 @@ public abstract class CommonUsbSerialPort implements UsbSerialPort {
                 if (offset == 0) {
                     writeBuffer = src;
                 } else {
-                    // bulkTransfer does not support offsets, make a copy.
                     System.arraycopy(src, offset, mWriteBuffer, 0, requestLength);
                     writeBuffer = mWriteBuffer;
                 }
-                if (timeout == 0 || offset == 0) {
-                    requestTimeout = timeout;
-                } else {
-                    requestTimeout = (int)(startTime + timeout - MonotonicClock.millis());
-                    if(requestTimeout == 0)
-                        requestTimeout = -1;
-                }
-                if (requestTimeout < 0) {
-                    actualLength = -2;
-                } else {
-                    actualLength = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, requestLength, requestTimeout);
-                }
+            }
+            if (timeout == 0 || offset == 0) {
+                requestTimeout = timeout;
+            } else {
+                requestTimeout = (int)(startTime + timeout - MonotonicClock.millis());
+                if(requestTimeout == 0)
+                    requestTimeout = -1;
+            }
+            if (requestTimeout < 0) {
+                actualLength = -2;
+            } else {
+                actualLength = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, requestLength, requestTimeout);
             }
             long elapsed = MonotonicClock.millis() - startTime;
             if (DEBUG) {

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
@@ -7,6 +7,7 @@
 package com.hoho.android.usbserial.driver;
 
 import android.hardware.usb.UsbConstants;
+import android.util.Log;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
@@ -97,8 +98,8 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         private static final int STATUS_CD = 0x80;
 
 
-        private boolean dtr = false;
-        private boolean rts = false;
+        private volatile boolean dtr = false;
+        private volatile boolean rts = false;
 
         // second port of Cp2105 has limited baudRate, dataBits, stopBits, parity
         // unsupported baudrate returns error at controlTransfer(), other parameters are silently ignored
@@ -133,10 +134,10 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
 
         @Override
         protected void openInt() throws IOException {
-            mIsRestrictedPort = mDevice.getInterfaceCount() == 2 && mPortNumber == 1;
             if(mPortNumber >= mDevice.getInterfaceCount()) {
                 throw new IOException("Unknown port number");
             }
+            mIsRestrictedPort = mDevice.getInterfaceCount() == 2 && mPortNumber == 1;
             UsbInterface dataIface = mDevice.getInterface(mPortNumber);
             if (!mConnection.claimInterface(dataIface, true)) {
                 throw new IOException("Could not claim interface " + mPortNumber);
@@ -161,10 +162,14 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         protected void closeInt() {
             try {
                 setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_DISABLE);
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error disabling UART", e);
+            }
             try {
                 mConnection.releaseInterface(mDevice.getInterface(mPortNumber));
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interface", e);
+            }
         }
 
         private void setBaudRate(int baudRate) throws IOException {

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -9,6 +9,8 @@ package com.hoho.android.usbserial.driver;
 
 import android.hardware.usb.UsbConstants;
 import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
 import android.util.Log;
 
 import com.hoho.android.usbserial.util.MonotonicClock;
@@ -84,9 +86,9 @@ public class FtdiSerialDriver implements UsbSerialDriver {
         private static final int RESET_PURGE_TX = 2;
 
         private boolean baudRateWithPort = false;
-        private boolean dtr = false;
-        private boolean rts = false;
-        private int breakConfig = 0;
+        private volatile boolean dtr = false;
+        private volatile boolean rts = false;
+        private volatile int breakConfig = 0;
 
         public FtdiSerialPort(UsbDevice device, int portNumber) {
             super(device, portNumber);
@@ -106,8 +108,20 @@ public class FtdiSerialDriver implements UsbSerialDriver {
             if (mDevice.getInterface(mPortNumber).getEndpointCount() < 2) {
                 throw new IOException("Not enough endpoints");
             }
-            mReadEndpoint = mDevice.getInterface(mPortNumber).getEndpoint(0);
-            mWriteEndpoint = mDevice.getInterface(mPortNumber).getEndpoint(1);
+            UsbInterface iface = mDevice.getInterface(mPortNumber);
+            for (int i = 0; i < iface.getEndpointCount(); i++) {
+                UsbEndpoint ep = iface.getEndpoint(i);
+                if (ep.getType() != UsbConstants.USB_ENDPOINT_XFER_BULK)
+                    continue;
+                if (ep.getDirection() == UsbConstants.USB_DIR_IN) {
+                    mReadEndpoint = ep;
+                } else {
+                    mWriteEndpoint = ep;
+                }
+            }
+            if (mReadEndpoint == null || mWriteEndpoint == null) {
+                throw new IOException("Could not find read and write endpoints");
+            }
 
             int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
                     RESET_ALL, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
@@ -137,7 +151,9 @@ public class FtdiSerialDriver implements UsbSerialDriver {
         protected void closeInt() {
             try {
                 mConnection.releaseInterface(mDevice.getInterface(mPortNumber));
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interface", e);
+            }
         }
 
         @Override
@@ -194,7 +210,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
         private void setBaudrate(int baudRate) throws IOException {
             int divisor, subdivisor, effectiveBaudRate;
             if (baudRate > 3500000) {
-                throw new UnsupportedOperationException("Baud rate to high");
+                throw new UnsupportedOperationException("Baud rate too high");
             } else if(baudRate >= 2500000) {
                 divisor = 0;
                 subdivisor = 0;
@@ -209,7 +225,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
                 subdivisor = divisor & 0x07;
                 divisor >>= 3;
                 if (divisor > 0x3fff) // exceeds bit 13 at 183 baud
-                    throw new UnsupportedOperationException("Baud rate to low");
+                    throw new UnsupportedOperationException("Baud rate too low");
                 effectiveBaudRate = (24000000 << 1) / ((divisor << 3) + subdivisor);
                 effectiveBaudRate = (effectiveBaudRate +1) >> 1;
             }
@@ -356,7 +372,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
             int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, MODEM_CONTROL_REQUEST,
                     value ? MODEM_CONTROL_RTS_ENABLE : MODEM_CONTROL_RTS_DISABLE, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
             if (result != 0) {
-                throw new IOException("Set DTR failed: result=" + result);
+                throw new IOException("Set RTS failed: result=" + result);
             }
             rts = value;
         }
@@ -415,7 +431,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
         public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException {
             if (purgeWriteBuffers) {
                 int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
-                        RESET_PURGE_RX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+                        RESET_PURGE_TX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
                 if (result != 0) {
                     throw new IOException("Purge write buffer failed: result=" + result);
                 }
@@ -423,7 +439,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
 
             if (purgeReadBuffers) {
                 int result = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, RESET_REQUEST,
-                        RESET_PURGE_TX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+                        RESET_PURGE_RX, mPortNumber+1, null, 0, USB_WRITE_TIMEOUT_MILLIS);
                 if (result != 0) {
                     throw new IOException("Purge read buffer failed: result=" + result);
                 }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/GsmModemSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/GsmModemSerialDriver.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class GsmModemSerialDriver implements UsbSerialDriver{
 
-    private final String TAG = GsmModemSerialDriver.class.getSimpleName();
+    private static final String TAG = GsmModemSerialDriver.class.getSimpleName();
 
     private final UsbDevice mDevice;
     private final UsbSerialPort mPort;
@@ -66,17 +66,17 @@ public class GsmModemSerialDriver implements UsbSerialDriver{
         protected void closeInt() {
             try {
                 mConnection.releaseInterface(mDataInterface);
-            } catch(Exception ignored) {}
-
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interface", e);
+            }
         }
 
-        private int initGsmModem() throws IOException {
+        private void initGsmModem() throws IOException {
             int len = mConnection.controlTransfer(
                     0x21, 0x22, 0x01, 0, null, 0, 5000);
             if(len < 0) {
                 throw new IOException("init failed");
             }
-            return len;
         }
 
         @Override

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProbeTable.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProbeTable.java
@@ -90,7 +90,7 @@ public class ProbeTable {
             try {
                 Method method = entry.getKey();
                 Object o = method.invoke(null, usbDevice);
-                if((boolean)o)
+                if(Boolean.TRUE.equals(o))
                     return entry.getValue();
             } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
                 throw new RuntimeException(e);

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class ProlificSerialDriver implements UsbSerialDriver {
 
-    private final String TAG = ProlificSerialDriver.class.getSimpleName();
+    private static final String TAG = ProlificSerialDriver.class.getSimpleName();
 
     private final static int[] standardBaudRates = {
             75, 150, 300, 600, 1200, 1800, 2400, 3600, 4800, 7200, 9600, 14400, 19200,
@@ -118,11 +118,11 @@ public class ProlificSerialDriver implements UsbSerialDriver {
         private int mControlLinesValue = 0;
         private int mBaudRate = -1, mDataBits = -1, mStopBits = -1, mParity = -1;
 
-        private int mStatus = 0;
+        private volatile int mStatus = 0;
         private volatile Thread mReadStatusThread = null;
         private final Object mReadStatusThreadLock = new Object();
-        private boolean mStopReadStatusThread = false;
-        private Exception mReadStatusException = null;
+        private volatile boolean mStopReadStatusThread = false;
+        private volatile Exception mReadStatusException = null;
 
 
         public ProlificSerialPort(UsbDevice device, int portNumber) {
@@ -252,7 +252,7 @@ public class ProlificSerialDriver implements UsbSerialDriver {
 
             /* throw and clear an exception which occurred in the status read thread */
             Exception readStatusException = mReadStatusException;
-            if (mReadStatusException != null) {
+            if (readStatusException != null) {
                 mReadStatusException = null;
                 throw new IOException(readStatusException);
             }
@@ -294,8 +294,8 @@ public class ProlificSerialDriver implements UsbSerialDriver {
             if(rawDescriptors == null || rawDescriptors.length < 14) {
                 throw new IOException("Could not get device descriptors");
             }
-            int usbVersion = (rawDescriptors[3] << 8) + rawDescriptors[2];
-            int deviceVersion = (rawDescriptors[13] << 8) + rawDescriptors[12];
+            int usbVersion = ((rawDescriptors[3] & 0xFF) << 8) | (rawDescriptors[2] & 0xFF);
+            int deviceVersion = ((rawDescriptors[13] & 0xFF) << 8) | (rawDescriptors[12] & 0xFF);
             byte maxPacketSize0 = rawDescriptors[7];
             if (mDevice.getDeviceClass() == 0x02 || maxPacketSize0 != 64) {
                 mDeviceType = DeviceType.DEVICE_TYPE_01;
@@ -325,9 +325,10 @@ public class ProlificSerialDriver implements UsbSerialDriver {
                     if (mReadStatusThread != null) {
                         try {
                             mStopReadStatusThread = true;
+                            mReadStatusThread.interrupt();
                             mReadStatusThread.join();
                         } catch (Exception e) {
-                            Log.w(TAG, "An error occured while waiting for status read thread", e);
+                            Log.w(TAG, "Error occurred while waiting for status read thread", e);
                         }
                         mStopReadStatusThread = false;
                         mReadStatusThread = null;
@@ -335,10 +336,14 @@ public class ProlificSerialDriver implements UsbSerialDriver {
                     }
                 }
                 resetDevice();
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error during close", e);
+            }
             try {
                 mConnection.releaseInterface(mDevice.getInterface(0));
-            } catch(Exception ignored) {}
+            } catch (Exception e) {
+                Log.w(TAG, "Error releasing interface", e);
+            }
         }
 
         private int filterBaudRate(int baudRate) {
@@ -376,7 +381,7 @@ public class ProlificSerialDriver implements UsbSerialDriver {
             baseline = 12000000 * 32;
             mantissa = baseline / baudRate;
             if (mantissa == 0) { // > unrealistic 384 MBaud
-                throw new UnsupportedOperationException("Baud rate to high");
+                throw new UnsupportedOperationException("Baud rate too high");
             }
             exponent = 0;
             if (mDeviceType == DeviceType.DEVICE_TYPE_T) {
@@ -385,7 +390,7 @@ public class ProlificSerialDriver implements UsbSerialDriver {
                         mantissa >>= 1;    /* divide by 2 */
                         exponent++;
                     } else { // < 7 baud
-                        throw new UnsupportedOperationException("Baud rate to low");
+                        throw new UnsupportedOperationException("Baud rate too low");
                     }
                 }
                 buf = mantissa + ((exponent & ~1) << 12) + ((exponent & 1) << 16) + (1 << 31);
@@ -396,7 +401,7 @@ public class ProlificSerialDriver implements UsbSerialDriver {
                         mantissa >>= 2;    /* divide by 4 */
                         exponent++;
                     } else { // < 45.8 baud
-                        throw new UnsupportedOperationException("Baud rate to low");
+                        throw new UnsupportedOperationException("Baud rate too low");
                     }
                 }
                 buf = mantissa + (exponent << 9) + (1 << 31);
@@ -582,15 +587,15 @@ public class ProlificSerialDriver implements UsbSerialDriver {
         public void purgeHwBuffers(boolean purgeWriteBuffers, boolean purgeReadBuffers) throws IOException {
             if (mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
                 int index = 0;
-                if(purgeWriteBuffers) index |= RESET_HXN_RX_PIPE;
-                if(purgeReadBuffers) index |= RESET_HXN_TX_PIPE;
+                if(purgeWriteBuffers) index |= RESET_HXN_TX_PIPE;
+                if(purgeReadBuffers) index |= RESET_HXN_RX_PIPE;
                 if(index != 0)
                     vendorOut(RESET_HXN_REQUEST, index, null);
             } else {
                 if (purgeWriteBuffers)
-                    vendorOut(FLUSH_RX_REQUEST, 0, null);
-                if (purgeReadBuffers)
                     vendorOut(FLUSH_TX_REQUEST, 0, null);
+                if (purgeReadBuffers)
+                    vendorOut(FLUSH_RX_REQUEST, 0, null);
             }
         }
 

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialProber.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/UsbSerialProber.java
@@ -80,7 +80,7 @@ public class UsbSerialProber {
                 driver = ctor.newInstance(usbDevice);
             } catch (NoSuchMethodException | IllegalArgumentException | InstantiationException |
                      IllegalAccessException | InvocationTargetException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("Failed to instantiate " + driverClass.getName(), e);
             }
             return driver;
         }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/SerialInputOutputManager.java
@@ -30,25 +30,25 @@ public class SerialInputOutputManager {
         STOPPING
     }
 
-    public static boolean DEBUG = false;
+    public static volatile boolean DEBUG = false;
 
     private static final String TAG = SerialInputOutputManager.class.getSimpleName();
     private static final int WRITE_BUFFER_SIZE = 4096;
 
-    private int mReadTimeout = 0;
-    private int mWriteTimeout = 0;
+    private volatile int mReadTimeout = 0;
+    private volatile int mWriteTimeout = 0;
     private int mReadQueueBufferCount = 0;
     //       no mReadQueueBufferSize, using mReadBuffer.size instead
 
     private final Object mReadBufferLock = new Object();
     private final Object mWriteBufferLock = new Object();
 
-    private ByteBuffer mReadBuffer; // default size = getReadEndpoint().getMaxPacketSize()
-    private ByteBuffer mWriteBuffer = ByteBuffer.allocate(WRITE_BUFFER_SIZE);
+    private volatile ByteBuffer mReadBuffer; // default size = getReadEndpoint().getMaxPacketSize()
+    private volatile ByteBuffer mWriteBuffer = ByteBuffer.allocate(WRITE_BUFFER_SIZE);
 
-    private int mThreadPriority = Process.THREAD_PRIORITY_URGENT_AUDIO;
+    private volatile int mThreadPriority = Process.THREAD_PRIORITY_URGENT_AUDIO;
     private final AtomicReference<State> mState = new AtomicReference<>(State.STOPPED);
-    private CountDownLatch mStartuplatch = new CountDownLatch(2);
+    private volatile CountDownLatch mStartuplatch = new CountDownLatch(2);
     private Listener mListener; // Synchronized by 'this'
     private final UsbSerialPort mSerialPort;
 
@@ -184,6 +184,10 @@ public class SerialInputOutputManager {
                 mState.set(State.RUNNING);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                mState.set(State.STOPPING);
+                synchronized (mWriteBufferLock) {
+                    mWriteBufferLock.notifyAll();
+                }
             }
         } else {
             throw new IllegalStateException("already started");
@@ -197,9 +201,10 @@ public class SerialInputOutputManager {
      * interrupt blocking read
      */
     public void stop() {
-        if(mState.compareAndSet(State.RUNNING, State.STOPPING)) {
+        if(mState.compareAndSet(State.RUNNING, State.STOPPING)
+                || mState.compareAndSet(State.STARTING, State.STOPPING)) {
             synchronized (mWriteBufferLock) {
-                mWriteBufferLock.notifyAll(); // wake up write thread to check the stop condition
+                mWriteBufferLock.notifyAll();
             }
             Log.i(TAG, "Stop requested");
         }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/XonXoffFilter.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/util/XonXoffFilter.java
@@ -10,7 +10,7 @@ import java.io.IOException;
  */
 
 public class XonXoffFilter {
-    private boolean xon = true;
+    private volatile boolean xon = true;
 
     public XonXoffFilter() {
     }


### PR DESCRIPTION
## Summary

Targeted fixes for thread safety, race conditions, error handling, and correctness issues across all drivers and utilities. No new APIs, no architectural changes.

### Thread safety (`volatile`)
- **Drivers**: DTR/RTS flags, `mReadRequest`, `DEBUG`, `breakConfig`, `mStatus`, `mDeviceType`, latency timer fields accessed across threads without visibility guarantees
- **SerialInputOutputManager**: `DEBUG`, `mReadTimeout`, `mWriteTimeout`, `mThreadPriority`, `mReadBuffer`, `mWriteBuffer`
- **XonXoffFilter**: `xon` field

### Correctness fixes
- **FtdiSerialDriver**: Assign endpoints by direction + bulk type instead of hardcoded index — prevents silent read/write swap if device enumerates endpoints in unexpected order
- **Ch34xSerialDriver**: `getStatus()` validates exact return length, not just `>= 0` — prevents returning stale/zeroed data on partial transfer
- **Cp21xxSerialDriver**: Port number validation before `mIsRestrictedPort` assignment
- **ProlificSerialDriver**: `interrupt()` before `join()` on status thread — prevents indefinite hang if thread is blocked on USB transfer
- **ProbeTable**: `Boolean.TRUE.equals(o)` instead of `(boolean)o` — prevents NPE if probe method returns null
- **ChromeCcdSerialDriver**: Use actual interface count instead of hardcoded 3
- **CdcAcmSerialDriver**: Guard against double-releasing same interface; null check on control endpoint count
- **CommonUsbSerialPort**: Null check on `mReadRequest` in `readAsync()` before queueing; `getSerial()` throws if port not open

### Error handling
- Replace silent `catch(Exception ignored){}` with `Log.w` in all driver close paths — makes USB debugging possible
- `testConnection` error message includes return code (`rc=`)

### Resource management
- `UsbRequest.close()` on Android O+ (was only cancelling, not closing)

### Other
- `static final` on TAG and constant fields that were incorrectly instance-scoped
- `LinkedList` → `ArrayList` for read queue (better random-access performance)
- Fix "occured" typo in log message

## Test plan
- [ ] Verify existing instrumented tests pass on connected devices
- [ ] Smoke test open/close/read/write on FTDI, Prolific, CP21xx, CH34x devices
- [ ] Verify `Log.w` messages appear in logcat during abnormal disconnect