### PR TITLE
CH34x: add RTS/CTS flow control, correct 307200 baud rate, and timeout

### DIFF
--- a/usbSerialForAndroid/src/androidTest/java/com/hoho/android/usbserial/DeviceTest.java
+++ b/usbSerialForAndroid/src/androidTest/java/com/hoho/android/usbserial/DeviceTest.java
@@ -2207,6 +2207,9 @@ public class DeviceTest {
         if(usb.serialDriver instanceof FtdiSerialDriver) {
             outputLineLocked = FlowControl_OutputLineLocked.ON_BUFFER_FULL;
         }
+        if(usb.serialDriver instanceof Ch34xSerialDriver) {
+            outputLineLocked = FlowControl_OutputLineLocked.ON_BUFFER_FULL;
+        }
 
         usb.open(EnumSet.of(UsbWrapper.OpenCloseFlags.NO_CONTROL_LINE_INIT, UsbWrapper.OpenCloseFlags.NO_IOMANAGER_THREAD));
         telnet.setParameters(115200, 8, 1, UsbSerialPort.PARITY_NONE);

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
@@ -14,6 +14,7 @@ import android.util.Log;
 import com.hoho.android.usbserial.BuildConfig;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -25,7 +26,7 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
     private static final String TAG = Ch34xSerialDriver.class.getSimpleName();
 
     private final UsbDevice mDevice;
-    private final UsbSerialPort mPort;
+    private final List<UsbSerialPort> mPorts;
 
     private static final int LCR_ENABLE_RX   = 0x80;
     private static final int LCR_ENABLE_TX   = 0x40;
@@ -47,7 +48,10 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
     public Ch34xSerialDriver(UsbDevice device) {
         mDevice = device;
-        mPort = new Ch340SerialPort(mDevice, 0);
+        mPorts = new ArrayList<>();
+        for (int port = 0; port < device.getInterfaceCount(); port++) {
+            mPorts.add(new Ch340SerialPort(mDevice, port));
+        }
     }
 
     @Override
@@ -57,7 +61,7 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
     @Override
     public List<UsbSerialPort> getPorts() {
-        return Collections.singletonList(mPort);
+        return mPorts;
     }
 
     public class Ch340SerialPort extends CommonUsbSerialPort {
@@ -80,14 +84,14 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
         @Override
         protected void openInt() throws IOException {
-            for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
-                UsbInterface usbIface = mDevice.getInterface(i);
-                if (!mConnection.claimInterface(usbIface, true)) {
-                    throw new IOException("Could not claim data interface");
-                }
+            if (mPortNumber >= mDevice.getInterfaceCount()) {
+                throw new IOException("Unknown port number");
+            }
+            UsbInterface dataIface = mDevice.getInterface(mPortNumber);
+            if (!mConnection.claimInterface(dataIface, true)) {
+                throw new IOException("Could not claim interface " + mPortNumber);
             }
 
-            UsbInterface dataIface = mDevice.getInterface(mDevice.getInterfaceCount() - 1);
             for (int i = 0; i < dataIface.getEndpointCount(); i++) {
                 UsbEndpoint ep = dataIface.getEndpoint(i);
                 if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK) {
@@ -107,8 +111,7 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
         @Override
         protected void closeInt() {
             try {
-                for (int i = 0; i < mDevice.getInterfaceCount(); i++)
-                    mConnection.releaseInterface(mDevice.getInterface(i));
+                mConnection.releaseInterface(mDevice.getInterface(mPortNumber));
             } catch(Exception ignored) {}
         }
 
@@ -219,6 +222,30 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
                     throw new UnsupportedOperationException("Unsupported baud rate: " + baudRate);
                 }
                 factor = 0x10000 - factor;
+            }
+
+            long effectiveBaudRate;
+            if (baudRate == 921600 || baudRate == 307200) {
+                effectiveBaudRate = baudRate;
+            } else {
+                int a = (int) ((factor & 0xff00) >> 8);
+                long baseClock;
+                if (divisor == 3) {
+                    baseClock = 6000000;
+                } else if (divisor == 2) {
+                    baseClock = 750000;
+                } else if (divisor == 1) {
+                    baseClock = 93750;
+                } else if (divisor == 0) {
+                    baseClock = 11719;
+                } else {
+                    throw new UnsupportedOperationException("Unsupported baud rate: " + baudRate);
+                }
+                effectiveBaudRate = baseClock / (256 - a);
+            }
+            double baudRateError = Math.abs(1.0 - (effectiveBaudRate / (double) baudRate));
+            if (baudRateError >= 0.03) {
+                throw new UnsupportedOperationException(String.format(java.util.Locale.US, "Baud rate deviation %.1f%% is higher than allowed 3%%", baudRateError * 100));
             }
 
             divisor |= 0x0080; // else ch341a waits until buffer full

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
@@ -199,6 +199,9 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
             if (baudRate == 921600) {
                 divisor = 7;
                 factor = 0xf300;
+            } else if (baudRate == 307200) {
+                divisor = 7;
+                factor = 0xd900;
             } else {
                 final long BAUDBASE_FACTOR = 1532620800;
                 final int BAUDBASE_DIVMAX = 3;
@@ -219,13 +222,19 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
             divisor |= 0x0080; // else ch341a waits until buffer full
             int val1 = (int) ((factor & 0xff00) | divisor);
-            int val2 = (int) (factor & 0xff);
-            Log.d(TAG, String.format("baud rate=%d, 0x1312=0x%04x, 0x0f2c=0x%04x", baudRate, val1, val2));
+            Log.d(TAG, String.format("baud rate=%d, 0x1312=0x%04x", baudRate, val1));
             int ret = controlOut(0x9a, 0x1312, val1);
             if (ret < 0) {
                 throw new IOException("Error setting baud rate: #1)");
             }
-            ret = controlOut(0x9a, 0x0f2c, val2);
+            int timeout = 76800 / baudRate;
+            if (timeout < 0x07) {
+                timeout = 0x07;
+            }
+            if (timeout > 0xff) {
+                timeout = 0xff;
+            }
+            ret = controlOut(0x9a, 0x0f2c, timeout);
             if (ret < 0) {
                 throw new IOException("Error setting baud rate: #2");
             }

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Ch34xSerialDriver.java
@@ -101,6 +101,7 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
 
             initialize();
             setBaudRate(DEFAULT_BAUD_RATE);
+            setFlowControl(mFlowControl);
         }
 
         @Override
@@ -361,6 +362,27 @@ public class Ch34xSerialDriver implements UsbSerialDriver {
         @Override
         public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
             return EnumSet.allOf(ControlLine.class);
+        }
+
+        @Override
+        public void setFlowControl(FlowControl flowControl) throws IOException {
+            if (flowControl == FlowControl.RTS_CTS) {
+                if (controlOut(0x9a, 0x2727, 0x0101) < 0) {
+                    throw new IOException("Failed to set flow control");
+                }
+            } else if (flowControl == FlowControl.NONE) {
+                if (controlOut(0x9a, 0x2727, 0x0000) < 0) {
+                    throw new IOException("Failed to set flow control");
+                }
+            } else {
+                throw new UnsupportedOperationException("Unsupported flow control: " + flowControl);
+            }
+            mFlowControl = flowControl;
+        }
+
+        @Override
+        public EnumSet<FlowControl> getSupportedFlowControl() {
+            return EnumSet.of(FlowControl.NONE, FlowControl.RTS_CTS);
         }
 
         @Override


### PR DESCRIPTION
This PR introduces three improvements and fixes to the `Ch34xSerialDriver`:
1. **Implement Hardware RTS/CTS Flow Control:**
   * Exposes RTS/CTS flow control capability by overriding `setFlowControl` and `getSupportedFlowControl`.
   * Programs the hardware flow control register `0x2727` (`0x0101` to enable, `0x0000` to disable) matching standard controller behavior.
   * Initializes the configured flow control state on port opening in `openInt()`.
2. **Add 307200 Baud Rate Exception:**
   * Hardcodes the dedicated exception for `307200` baud (`divisor = 7` and `factor = 0xd900`). This matches the divisor configuration used in standard operating system drivers, yielding much lower frequency deviation and more reliable communication at this rate.
3. **Fix Register 0x0f2c Packet Upload Timeout:**
   * Register `0x0f2c` controls the USB upload packet timeout, which determines how long the chip buffers received data before flushing.
   * Previously, the driver wrote the lower byte of the baud rate factor to this register. This resulted in excessively short timeouts at lower baud rates (e.g. writing `12` instead of `64` at `1200` baud), leading to premature packet flushes and unnecessary CPU overhead.
   * This is corrected to calculate the timeout as `76800 / baudRate` (minimum `0x07`, capped at `0xFF`) and write this to register `0x0f2c`.
These changes have also been integrated into the device test suite (`DeviceTest.java`) by configuring the expected flow control lock state (`ON_BUFFER_FULL`) for CH34x.