### PR TITLE
FTDI: prevent ArrayIndexOutOfBoundsException on small read buffers

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -122,6 +122,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
                 throw new IOException("Init RTS,DTR failed: result=" + result);
             }
             setFlowControl(mFlowControl);
+            setLatencyTimer(16);
 
             // mDevice.getVersion() would require API 23
             byte[] rawDescriptors = mConnection.getRawDescriptors();
@@ -178,6 +179,7 @@ public class FtdiSerialDriver implements UsbSerialDriver {
         }
 
         protected int readFilter(byte[] buffer, int totalBytesRead) throws IOException {
+            totalBytesRead = Math.min(totalBytesRead, buffer.length);
             final int maxPacketSize = mReadEndpoint.getMaxPacketSize();
             int destPos = 0;
             for(int srcPos = 0; srcPos < totalBytesRead; srcPos += maxPacketSize) {


### PR DESCRIPTION
## Description

This PR addresses two areas in the FTDI serial driver:
1. **Prevents `ArrayIndexOutOfBoundsException` on Small Read Buffers**:  (#631)
   When reading from the port into a small buffer (e.g. less than 64/512 bytes depending on device speed), some Android devices/kernels return `totalBytesRead` equal to the USB transfer packet size (`maxPacketSize`), even though the requested length/buffer size was smaller. When this happens, [readFilter()](file:///home/san/tmp/usb-serial-for-android/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/FtdiSerialDriver.java#L181-L194) calculates indexing up to the full packet length, causing `System.arraycopy` to throw an `ArrayIndexOutOfBoundsException`.
   * **Fix**: Clamp `totalBytesRead` to `buffer.length` upon entering `readFilter()`. This prevents the crash and ensures the user receives the maximum possible filtered payload that fits inside their buffer.

2. **Auto-initializes the Latency Timer**:
   FTDI chips have a default latency timer of 16 ms. The driver implements `setLatencyTimer()` but does not call it automatically during port startup.
   * **Improvement**: Added `setLatencyTimer(16)` inside `openInt()`. Explicitly setting this ensures the device starts in a clean, predictable state on open. Without this call, the driver can inherit custom latency configurations (e.g., 1 ms configured by other drivers or apps) from previous connections that did not physically power cycle the USB bus (common with OTG connections and hubs).

## Warning

The user should still be warned (via documentation or best practices) to use buffers >= 64 bytes (or >= 512 bytes for H-series devices, if we support them in the future.) to prevent hardware-level packet truncation and data loss.