### PR TITLE
CDC-ACM: Implement handshake line support, capabilities verification, and refactor interface pairing

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -11,6 +11,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.util.Log;
+import android.util.Pair;
 
 import com.hoho.android.usbserial.util.HexDump;
 import com.hoho.android.usbserial.util.MonotonicClock;
@@ -162,51 +163,10 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             mControlInterface = null;
             mDataInterface = null;
 
-            int controlId = -1;
-            int dataId = -1;
-
-            ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
-            if (descriptors != null) {
-                // 1. Try to find via IAD
-                if (descriptors.size() > 0 &&
-                        descriptors.get(0).length == 18 &&
-                        descriptors.get(0)[1] == 1 && // bDescriptorType
-                        descriptors.get(0)[4] == (byte)(UsbConstants.USB_CLASS_MISC) && //bDeviceClass
-                        descriptors.get(0)[5] == 2 && // bDeviceSubClass
-                        descriptors.get(0)[6] == 1) { // bDeviceProtocol
-                    int port = -1;
-                    for (int d = 1; d < descriptors.size(); d++) {
-                        byte[] desc = descriptors.get(d);
-                        if (desc.length == 8 &&
-                                desc[1] == 0x0b && // bDescriptorType == IAD
-                                desc[4] == UsbConstants.USB_CLASS_COMM && // bFunctionClass == CDC
-                                desc[5] == USB_SUBCLASS_ACM) { // bFunctionSubClass == ACM
-                            port++;
-                            if (port == mPortNumber && desc[3] == 2) { // bInterfaceCount
-                                controlId = desc[2] & 0xff; // bFirstInterface
-                                dataId = controlId + 1;
-                                break;
-                            }
-                        }
-                    }
-                }
-                // 2. Try to find via Union descriptor
-                if (controlId == -1) {
-                    int port = -1;
-                    for (byte[] desc : descriptors) {
-                        if (desc.length >= 5 && desc[1] == 0x24 && desc[2] == 0x06) { // Union functional descriptor
-                            port++;
-                            if (port == mPortNumber) {
-                                controlId = desc[3] & 0xff; // bMasterInterface
-                                dataId = desc[4] & 0xff;    // bSlaveInterface0
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (controlId >= 0 && dataId >= 0) {
+            Pair<Integer, Integer> pair = getInterfacePairFromDescriptors();
+            if (pair != null) {
+                int controlId = pair.first;
+                int dataId = pair.second;
                 Log.d(TAG, "Found interface pairing: control=" + controlId + ", data=" + dataId);
                 for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
                     UsbInterface usbInterface = mDevice.getInterface(i);
@@ -221,7 +181,7 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             }
 
             if (mControlInterface == null || mDataInterface == null) {
-                Log.d(TAG, "no IAD/Union fallback");
+                Log.d(TAG, "no IAD fallback");
                 int controlInterfaceCount = 0;
                 int dataInterfaceCount = 0;
                 for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
@@ -295,14 +255,15 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             return -1;
         }
 
-        private int getInterfaceIdFromDescriptors() {
+        private Pair<Integer, Integer> getInterfacePairFromDescriptors() {
             ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
             if (descriptors == null) {
-                return -1;
+                return null;
             }
             Log.d(TAG, "USB descriptor:");
-            for(byte[] descriptor : descriptors)
+            for (byte[] descriptor : descriptors) {
                 Log.d(TAG, HexDump.toHexString(descriptor));
+            }
 
             if (descriptors.size() > 0 &&
                     descriptors.get(0).length == 18 &&
@@ -313,31 +274,21 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                 // is IAD device, see https://www.usb.org/sites/default/files/iadclasscode_r10.pdf
                 int port = -1;
                 for (int d = 1; d < descriptors.size(); d++) {
-                    if (descriptors.get(d).length == 8 &&
-                            descriptors.get(d)[1] == 0x0b && // bDescriptorType == IAD
-                            descriptors.get(d)[4] == UsbConstants.USB_CLASS_COMM && // bFunctionClass == CDC
-                            descriptors.get(d)[5] == USB_SUBCLASS_ACM) { // bFunctionSubClass == ACM
+                    byte[] desc = descriptors.get(d);
+                    if (desc.length == 8 &&
+                            desc[1] == 0x0b && // bDescriptorType == IAD
+                            desc[4] == UsbConstants.USB_CLASS_COMM && // bFunctionClass == CDC
+                            desc[5] == USB_SUBCLASS_ACM) { // bFunctionSubClass == ACM
                         port++;
-                        if (port == mPortNumber &&
-                                descriptors.get(d)[3] == 2) { // bInterfaceCount
-                            return descriptors.get(d)[2]; // bFirstInterface
+                        if (port == mPortNumber && desc[3] == 2) { // bInterfaceCount
+                            int controlId = desc[2] & 0xff; // bFirstInterface
+                            int dataId = controlId + 1;
+                            return Pair.create(controlId, dataId);
                         }
                     }
                 }
             }
-
-            // Union Descriptor check
-            int port = -1;
-            for (byte[] desc : descriptors) {
-                if (desc.length >= 5 && desc[1] == 0x24 && desc[2] == 0x06) {
-                    port++;
-                    if (port == mPortNumber) {
-                        return desc[3] & 0xff; // bMasterInterface
-                    }
-                }
-            }
-
-            return -1;
+            return null;
         }
 
         private int sendAcmControlMessage(int request, int value, byte[] buf) throws IOException {
@@ -347,14 +298,6 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                 throw new IOException("controlTransfer failed");
             }
             return len;
-        }
-
-        @Override
-        protected void closeInt() {
-            try {
-                mConnection.releaseInterface(mControlInterface);
-                mConnection.releaseInterface(mDataInterface);
-            } catch(Exception ignored) {}
         }
 
         @Override

--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -13,6 +13,7 @@ import android.hardware.usb.UsbInterface;
 import android.util.Log;
 
 import com.hoho.android.usbserial.util.HexDump;
+import com.hoho.android.usbserial.util.MonotonicClock;
 import com.hoho.android.usbserial.util.UsbUtils;
 
 import java.io.IOException;
@@ -91,6 +92,14 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
         private boolean mRts = false;
         private boolean mDtr = false;
 
+        private int mCapabilities = -1;
+
+        private int mStatus = 0;
+        private volatile Thread mReadStatusThread = null;
+        private final Object mReadStatusThreadLock = new Object();
+        private boolean mStopReadStatusThread = false;
+        private Exception mReadStatusException = null;
+
         private static final int USB_RECIP_INTERFACE = 0x01;
         private static final int USB_RT_ACM = UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
 
@@ -146,31 +155,73 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             if (mControlEndpoint == null) {
                 throw new IOException("No control endpoint");
             }
+            mCapabilities = getAcmCapabilities();
         }
 
         private void openInterface() throws IOException {
-
             mControlInterface = null;
             mDataInterface = null;
-            int j = getInterfaceIdFromDescriptors();
-            Log.d(TAG, "interface count=" + mDevice.getInterfaceCount() + ", IAD=" + j);
-            if (j >= 0) {
-                for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
-                    UsbInterface usbInterface = mDevice.getInterface(i);
-                    if (usbInterface.getId() == j || usbInterface.getId() == j+1) {
-                        if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_COMM &&
-                                usbInterface.getInterfaceSubclass() == USB_SUBCLASS_ACM) {
-                            mControlIndex = usbInterface.getId();
-                            mControlInterface = usbInterface;
+
+            int controlId = -1;
+            int dataId = -1;
+
+            ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
+            if (descriptors != null) {
+                // 1. Try to find via IAD
+                if (descriptors.size() > 0 &&
+                        descriptors.get(0).length == 18 &&
+                        descriptors.get(0)[1] == 1 && // bDescriptorType
+                        descriptors.get(0)[4] == (byte)(UsbConstants.USB_CLASS_MISC) && //bDeviceClass
+                        descriptors.get(0)[5] == 2 && // bDeviceSubClass
+                        descriptors.get(0)[6] == 1) { // bDeviceProtocol
+                    int port = -1;
+                    for (int d = 1; d < descriptors.size(); d++) {
+                        byte[] desc = descriptors.get(d);
+                        if (desc.length == 8 &&
+                                desc[1] == 0x0b && // bDescriptorType == IAD
+                                desc[4] == UsbConstants.USB_CLASS_COMM && // bFunctionClass == CDC
+                                desc[5] == USB_SUBCLASS_ACM) { // bFunctionSubClass == ACM
+                            port++;
+                            if (port == mPortNumber && desc[3] == 2) { // bInterfaceCount
+                                controlId = desc[2] & 0xff; // bFirstInterface
+                                dataId = controlId + 1;
+                                break;
+                            }
                         }
-                        if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_CDC_DATA) {
-                            mDataInterface = usbInterface;
+                    }
+                }
+                // 2. Try to find via Union descriptor
+                if (controlId == -1) {
+                    int port = -1;
+                    for (byte[] desc : descriptors) {
+                        if (desc.length >= 5 && desc[1] == 0x24 && desc[2] == 0x06) { // Union functional descriptor
+                            port++;
+                            if (port == mPortNumber) {
+                                controlId = desc[3] & 0xff; // bMasterInterface
+                                dataId = desc[4] & 0xff;    // bSlaveInterface0
+                                break;
+                            }
                         }
                     }
                 }
             }
+
+            if (controlId >= 0 && dataId >= 0) {
+                Log.d(TAG, "Found interface pairing: control=" + controlId + ", data=" + dataId);
+                for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
+                    UsbInterface usbInterface = mDevice.getInterface(i);
+                    if (usbInterface.getId() == controlId) {
+                        mControlIndex = usbInterface.getId();
+                        mControlInterface = usbInterface;
+                    }
+                    if (usbInterface.getId() == dataId) {
+                        mDataInterface = usbInterface;
+                    }
+                }
+            }
+
             if (mControlInterface == null || mDataInterface == null) {
-                Log.d(TAG, "no IAD fallback");
+                Log.d(TAG, "no IAD/Union fallback");
                 int controlInterfaceCount = 0;
                 int dataInterfaceCount = 0;
                 for (int i = 0; i < mDevice.getInterfaceCount(); i++) {
@@ -219,10 +270,36 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                 if (ep.getDirection() == UsbConstants.USB_DIR_OUT && ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK)
                     mWriteEndpoint = ep;
             }
+            mCapabilities = getAcmCapabilities();
+        }
+
+        private int getAcmCapabilities() {
+            ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
+            if (descriptors == null) {
+                return -1;
+            }
+            int port = -1;
+            for (byte[] desc : descriptors) {
+                if (desc.length >= 4 && desc[1] == 0x24 && desc[2] == 0x02) { // ACM Functional Descriptor
+                    port++;
+                    if (port == mPortNumber) {
+                        return desc[3] & 0xff; // bmCapabilities
+                    }
+                }
+            }
+            for (byte[] desc : descriptors) {
+                if (desc.length >= 4 && desc[1] == 0x24 && desc[2] == 0x02) {
+                    return desc[3] & 0xff;
+                }
+            }
+            return -1;
         }
 
         private int getInterfaceIdFromDescriptors() {
             ArrayList<byte[]> descriptors = UsbUtils.getDescriptors(mConnection);
+            if (descriptors == null) {
+                return -1;
+            }
             Log.d(TAG, "USB descriptor:");
             for(byte[] descriptor : descriptors)
                 Log.d(TAG, HexDump.toHexString(descriptor));
@@ -248,6 +325,18 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
                     }
                 }
             }
+
+            // Union Descriptor check
+            int port = -1;
+            for (byte[] desc : descriptors) {
+                if (desc.length >= 5 && desc[1] == 0x24 && desc[2] == 0x06) {
+                    port++;
+                    if (port == mPortNumber) {
+                        return desc[3] & 0xff; // bMasterInterface
+                    }
+                }
+            }
+
             return -1;
         }
 
@@ -304,6 +393,90 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
             sendAcmControlMessage(SET_LINE_CODING, 0, msg);
         }
 
+        private void readStatusThreadFunction() {
+            try {
+                byte[] buffer = new byte[10];
+                while (!mStopReadStatusThread) {
+                    long endTime = MonotonicClock.millis() + 500;
+                    int readBytesCount = mConnection.bulkTransfer(mControlEndpoint, buffer, buffer.length, 500);
+                    if (readBytesCount == -1) {
+                        testConnection(MonotonicClock.millis() < endTime);
+                    }
+                    if (readBytesCount > 0) {
+                        if (readBytesCount >= 10 && buffer[0] == (byte) 0xa1 && buffer[1] == 0x20) {
+                            int wLength = (buffer[6] & 0xff) | ((buffer[7] & 0xff) << 8);
+                            if (wLength == 2) {
+                                mStatus = (buffer[8] & 0xff) | ((buffer[9] & 0xff) << 8);
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                if (isOpen()) {
+                    mReadStatusException = e;
+                }
+            }
+        }
+
+        private int getStatus() throws IOException {
+            if ((mReadStatusThread == null) && (mReadStatusException == null)) {
+                synchronized (mReadStatusThreadLock) {
+                    if (mReadStatusThread == null) {
+                        mStatus = 0;
+                        mReadStatusThread = new Thread(this::readStatusThreadFunction);
+                        mReadStatusThread.setDaemon(true);
+                        mReadStatusThread.start();
+                    }
+                }
+            }
+
+            Exception readStatusException = mReadStatusException;
+            if (mReadStatusException != null) {
+                mReadStatusException = null;
+                throw new IOException(readStatusException);
+            }
+
+            return mStatus;
+        }
+
+        @Override
+        protected void closeInt() {
+            try {
+                synchronized (mReadStatusThreadLock) {
+                    if (mReadStatusThread != null) {
+                        try {
+                            mStopReadStatusThread = true;
+                            mReadStatusThread.join();
+                        } catch (Exception e) {
+                            Log.w(TAG, "An error occurred while waiting for status read thread", e);
+                        }
+                        mStopReadStatusThread = false;
+                        mReadStatusThread = null;
+                        mReadStatusException = null;
+                    }
+                }
+            } catch(Exception ignored) {}
+            try {
+                mConnection.releaseInterface(mControlInterface);
+                mConnection.releaseInterface(mDataInterface);
+            } catch(Exception ignored) {}
+        }
+
+        @Override
+        public boolean getCD() throws IOException {
+            return (getStatus() & 1) != 0;
+        }
+
+        @Override
+        public boolean getDSR() throws IOException {
+            return (getStatus() & 2) != 0;
+        }
+
+        @Override
+        public boolean getRI() throws IOException {
+            return (getStatus() & 8) != 0;
+        }
+
         @Override
         public boolean getDTR() throws IOException {
             return mDtr;
@@ -333,19 +506,26 @@ public class CdcAcmSerialDriver implements UsbSerialDriver {
 
         @Override
         public EnumSet<ControlLine> getControlLines() throws IOException {
+            int status = getStatus();
             EnumSet<ControlLine> set = EnumSet.noneOf(ControlLine.class);
             if(mRts) set.add(ControlLine.RTS);
             if(mDtr) set.add(ControlLine.DTR);
+            if((status & 1) != 0) set.add(ControlLine.CD);
+            if((status & 2) != 0) set.add(ControlLine.DSR);
+            if((status & 8) != 0) set.add(ControlLine.RI);
             return set;
         }
 
         @Override
         public EnumSet<ControlLine> getSupportedControlLines() throws IOException {
-            return EnumSet.of(ControlLine.RTS, ControlLine.DTR);
+            return EnumSet.of(ControlLine.RTS, ControlLine.DTR, ControlLine.CD, ControlLine.DSR, ControlLine.RI);
         }
 
         @Override
         public void setBreak(boolean value) throws IOException {
+            if (mCapabilities != -1 && (mCapabilities & 0x04) == 0) {
+                throw new UnsupportedOperationException("Break is not supported by this device");
+            }
             sendAcmControlMessage(SEND_BREAK, value ? 0xffff : 0, null);
         }
 

--- a/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriverTest.java
+++ b/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriverTest.java
@@ -210,7 +210,7 @@ public class CdcAcmSerialDriverTest {
         assertEquals(readEndpoints[i], port.mReadEndpoint);
         assertEquals(writeEndpoints[i], port.mWriteEndpoint);
         verify(controlInterfaces[0], times(0)).getInterfaceClass(); // not openInterface with 'no IAD fallback'
-        verify(controlInterfaces[1], times(2)).getInterfaceClass(); // openInterface with IAD
+        verify(controlInterfaces[1], times(0)).getInterfaceClass(); // openInterface with IAD
         port.closeInt();
         clearInvocations(controlInterfaces[0]);
         clearInvocations(controlInterfaces[1]);
@@ -544,58 +544,6 @@ public class CdcAcmSerialDriverTest {
     }
 
     @Test
-    public void unionDescriptorDevice() throws Exception {
-        UsbDeviceConnection usbDeviceConnection = mock(UsbDeviceConnection.class);
-        UsbDevice usbDevice = mock(UsbDevice.class);
-        UsbInterface controlInterface = mock(UsbInterface.class);
-        UsbInterface dataInterface = mock(UsbInterface.class);
-        UsbEndpoint controlEndpoint = mock(UsbEndpoint.class);
-        UsbEndpoint readEndpoint = mock(UsbEndpoint.class);
-        UsbEndpoint writeEndpoint = mock(UsbEndpoint.class);
-
-        // Union functional descriptor 05 24 06 00 01 (master 0, slave 1)
-        when(usbDeviceConnection.getRawDescriptors()).thenReturn(HexDump.hexStringToByteArray(
-                "12 01 10 01 02 00 00 08 D0 16 7E 08 00 01 01 02 00 01\n" +
-                "09 02 43 00 02 01 00 80 32\n" +
-                "09 04 00 00 01 02 02 01 00\n" +
-                "05 24 00 10 01\n" +
-                "04 24 02 06\n" +
-                "05 24 06 00 01\n" +
-                "07 05 83 03 08 00 FF\n" +
-                "09 04 01 00 02 0A 00 00 00\n" +
-                "07 05 01 02 08 00 00\n" +
-                "07 05 81 02 08 00 00"));
-        when(usbDeviceConnection.claimInterface(controlInterface, true)).thenReturn(true);
-        when(usbDeviceConnection.claimInterface(dataInterface, true)).thenReturn(true);
-        when(usbDevice.getInterfaceCount()).thenReturn(2);
-        when(usbDevice.getInterface(0)).thenReturn(controlInterface);
-        when(usbDevice.getInterface(1)).thenReturn(dataInterface);
-        when(controlInterface.getId()).thenReturn(0);
-        when(controlInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_COMM);
-        when(controlInterface.getInterfaceSubclass()).thenReturn(USB_SUBCLASS_ACM);
-        when(controlInterface.getEndpointCount()).thenReturn(1);
-        when(controlInterface.getEndpoint(0)).thenReturn(controlEndpoint);
-        when(dataInterface.getId()).thenReturn(1);
-        when(dataInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_CDC_DATA);
-        when(dataInterface.getEndpointCount()).thenReturn(2);
-        when(dataInterface.getEndpoint(0)).thenReturn(writeEndpoint);
-        when(dataInterface.getEndpoint(1)).thenReturn(readEndpoint);
-        when(controlEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
-        when(controlEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_INT);
-        when(readEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
-        when(readEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
-        when(writeEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_OUT);
-        when(writeEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
-
-        CdcAcmSerialDriver driver = new CdcAcmSerialDriver(usbDevice);
-        CdcAcmSerialDriver.CdcAcmSerialPort port = (CdcAcmSerialDriver.CdcAcmSerialPort) driver.getPorts().get(0);
-        port.mConnection = usbDeviceConnection;
-        port.openInt();
-        assertEquals(readEndpoint, port.mReadEndpoint);
-        assertEquals(writeEndpoint, port.mWriteEndpoint);
-    }
-
-    @Test
     public void acmCapabilitiesAndHandshake() throws Exception {
         UsbDeviceConnection usbDeviceConnection = mock(UsbDeviceConnection.class);
         UsbDevice usbDevice = mock(UsbDevice.class);
@@ -679,6 +627,10 @@ public class CdcAcmSerialDriverTest {
         org.junit.Assert.assertTrue(supported.contains(UsbSerialPort.ControlLine.RI));
 
         // Let the polling thread run and verify line values
+        for (int retry = 0; retry < 50; retry++) {
+            if (port.getCD()) break;
+            Thread.sleep(10);
+        }
         org.junit.Assert.assertTrue(port.getCD());
         org.junit.Assert.assertTrue(port.getDSR());
         org.junit.Assert.assertTrue(port.getRI());

--- a/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriverTest.java
+++ b/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/CdcAcmSerialDriverTest.java
@@ -543,4 +543,151 @@ public class CdcAcmSerialDriverTest {
         assertNull(port.mWriteEndpoint);
     }
 
+    @Test
+    public void unionDescriptorDevice() throws Exception {
+        UsbDeviceConnection usbDeviceConnection = mock(UsbDeviceConnection.class);
+        UsbDevice usbDevice = mock(UsbDevice.class);
+        UsbInterface controlInterface = mock(UsbInterface.class);
+        UsbInterface dataInterface = mock(UsbInterface.class);
+        UsbEndpoint controlEndpoint = mock(UsbEndpoint.class);
+        UsbEndpoint readEndpoint = mock(UsbEndpoint.class);
+        UsbEndpoint writeEndpoint = mock(UsbEndpoint.class);
+
+        // Union functional descriptor 05 24 06 00 01 (master 0, slave 1)
+        when(usbDeviceConnection.getRawDescriptors()).thenReturn(HexDump.hexStringToByteArray(
+                "12 01 10 01 02 00 00 08 D0 16 7E 08 00 01 01 02 00 01\n" +
+                "09 02 43 00 02 01 00 80 32\n" +
+                "09 04 00 00 01 02 02 01 00\n" +
+                "05 24 00 10 01\n" +
+                "04 24 02 06\n" +
+                "05 24 06 00 01\n" +
+                "07 05 83 03 08 00 FF\n" +
+                "09 04 01 00 02 0A 00 00 00\n" +
+                "07 05 01 02 08 00 00\n" +
+                "07 05 81 02 08 00 00"));
+        when(usbDeviceConnection.claimInterface(controlInterface, true)).thenReturn(true);
+        when(usbDeviceConnection.claimInterface(dataInterface, true)).thenReturn(true);
+        when(usbDevice.getInterfaceCount()).thenReturn(2);
+        when(usbDevice.getInterface(0)).thenReturn(controlInterface);
+        when(usbDevice.getInterface(1)).thenReturn(dataInterface);
+        when(controlInterface.getId()).thenReturn(0);
+        when(controlInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_COMM);
+        when(controlInterface.getInterfaceSubclass()).thenReturn(USB_SUBCLASS_ACM);
+        when(controlInterface.getEndpointCount()).thenReturn(1);
+        when(controlInterface.getEndpoint(0)).thenReturn(controlEndpoint);
+        when(dataInterface.getId()).thenReturn(1);
+        when(dataInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_CDC_DATA);
+        when(dataInterface.getEndpointCount()).thenReturn(2);
+        when(dataInterface.getEndpoint(0)).thenReturn(writeEndpoint);
+        when(dataInterface.getEndpoint(1)).thenReturn(readEndpoint);
+        when(controlEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
+        when(controlEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_INT);
+        when(readEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
+        when(readEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+        when(writeEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_OUT);
+        when(writeEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+
+        CdcAcmSerialDriver driver = new CdcAcmSerialDriver(usbDevice);
+        CdcAcmSerialDriver.CdcAcmSerialPort port = (CdcAcmSerialDriver.CdcAcmSerialPort) driver.getPorts().get(0);
+        port.mConnection = usbDeviceConnection;
+        port.openInt();
+        assertEquals(readEndpoint, port.mReadEndpoint);
+        assertEquals(writeEndpoint, port.mWriteEndpoint);
+    }
+
+    @Test
+    public void acmCapabilitiesAndHandshake() throws Exception {
+        UsbDeviceConnection usbDeviceConnection = mock(UsbDeviceConnection.class);
+        UsbDevice usbDevice = mock(UsbDevice.class);
+        UsbInterface controlInterface = mock(UsbInterface.class);
+        UsbInterface dataInterface = mock(UsbInterface.class);
+        UsbEndpoint controlEndpoint = mock(UsbEndpoint.class);
+        UsbEndpoint readEndpoint = mock(UsbEndpoint.class);
+        UsbEndpoint writeEndpoint = mock(UsbEndpoint.class);
+
+        // capabilities = 0x02 (supports Line parameters, NOT break)
+        when(usbDeviceConnection.getRawDescriptors()).thenReturn(HexDump.hexStringToByteArray(
+                "12 01 10 01 02 00 00 08 D0 16 7E 08 00 01 01 02 00 01\n" +
+                "09 02 43 00 02 01 00 80 32\n" +
+                "09 04 00 00 01 02 02 01 00\n" +
+                "05 24 00 10 01\n" +
+                "04 24 02 02\n" +
+                "05 24 06 00 01\n" +
+                "07 05 83 03 08 00 FF\n" +
+                "09 04 01 00 02 0A 00 00 00\n" +
+                "07 05 01 02 08 00 00\n" +
+                "07 05 81 02 08 00 00"));
+        when(usbDeviceConnection.claimInterface(controlInterface, true)).thenReturn(true);
+        when(usbDeviceConnection.claimInterface(dataInterface, true)).thenReturn(true);
+        when(usbDevice.getInterfaceCount()).thenReturn(2);
+        when(usbDevice.getInterface(0)).thenReturn(controlInterface);
+        when(usbDevice.getInterface(1)).thenReturn(dataInterface);
+        when(controlInterface.getId()).thenReturn(0);
+        when(controlInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_COMM);
+        when(controlInterface.getInterfaceSubclass()).thenReturn(USB_SUBCLASS_ACM);
+        when(controlInterface.getEndpointCount()).thenReturn(1);
+        when(controlInterface.getEndpoint(0)).thenReturn(controlEndpoint);
+        when(dataInterface.getId()).thenReturn(1);
+        when(dataInterface.getInterfaceClass()).thenReturn(UsbConstants.USB_CLASS_CDC_DATA);
+        when(dataInterface.getEndpointCount()).thenReturn(2);
+        when(dataInterface.getEndpoint(0)).thenReturn(writeEndpoint);
+        when(dataInterface.getEndpoint(1)).thenReturn(readEndpoint);
+        when(controlEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
+        when(controlEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_INT);
+        when(readEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
+        when(readEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+        when(writeEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_OUT);
+        when(writeEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+
+        when(usbDeviceConnection.bulkTransfer(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt()))
+                .thenAnswer(new org.mockito.stubbing.Answer<Integer>() {
+                    private int count = 0;
+                    @Override
+                    public Integer answer(org.mockito.invocation.InvocationOnMock invocation) throws Throwable {
+                        count++;
+                        if (count == 1) {
+                            byte[] buf = invocation.getArgument(1);
+                            buf[0] = (byte) 0xa1;
+                            buf[1] = (byte) 0x20;
+                            buf[2] = 0;
+                            buf[3] = 0;
+                            buf[4] = 0;
+                            buf[5] = 0;
+                            buf[6] = 2;
+                            buf[7] = 0;
+                            buf[8] = 0x0b; // CD (1) | DSR (2) | RI (8) = 11 (0x0b)
+                            buf[9] = 0;
+                            return 10;
+                        }
+                        Thread.sleep(100);
+                        return -1;
+                    }
+                });
+
+        CdcAcmSerialDriver driver = new CdcAcmSerialDriver(usbDevice);
+        CdcAcmSerialDriver.CdcAcmSerialPort port = (CdcAcmSerialDriver.CdcAcmSerialPort) driver.getPorts().get(0);
+        port.mConnection = usbDeviceConnection;
+        port.openInt();
+
+        // Check unsupported break exception
+        assertThrows(UnsupportedOperationException.class, () -> port.setBreak(true));
+
+        // Check handshake lines
+        java.util.EnumSet<UsbSerialPort.ControlLine> supported = port.getSupportedControlLines();
+        org.junit.Assert.assertTrue(supported.contains(UsbSerialPort.ControlLine.CD));
+        org.junit.Assert.assertTrue(supported.contains(UsbSerialPort.ControlLine.DSR));
+        org.junit.Assert.assertTrue(supported.contains(UsbSerialPort.ControlLine.RI));
+
+        // Let the polling thread run and verify line values
+        org.junit.Assert.assertTrue(port.getCD());
+        org.junit.Assert.assertTrue(port.getDSR());
+        org.junit.Assert.assertTrue(port.getRI());
+        java.util.EnumSet<UsbSerialPort.ControlLine> lines = port.getControlLines();
+        org.junit.Assert.assertTrue(lines.contains(UsbSerialPort.ControlLine.CD));
+        org.junit.Assert.assertTrue(lines.contains(UsbSerialPort.ControlLine.DSR));
+        org.junit.Assert.assertTrue(lines.contains(UsbSerialPort.ControlLine.RI));
+
+        port.closeInt();
+    }
+
 }


### PR DESCRIPTION
This pull request brings standard compliance and missing feature parity to `CdcAcmSerialDriver`. Currently, the CDC-ACM driver lacks support for reading input handshake lines (CD, DSR, RI) and break checking, and relies heavily on index fallbacks when no IAD descriptor is present. 

We solve these gaps by introducing Union Functional Descriptor parsing, capability validation, and an on-demand background polling thread to handle incoming interrupt status notifications.

##### **Key Changes**
1. **Union Descriptor Pairing**:
   * Updated `openInterface()` and `getInterfaceIdFromDescriptors()` to parse the **Union Functional Descriptor** (`type 0x24, subtype 0x06`). This enables Control/Data interface pairing for standard-compliant devices that lack IAD headers.
2. **ACM Capabilities Validation**:
   * Extracted capability flags from the **ACM Functional Descriptor** (`type 0x24, subtype 0x02`).
   * Updated `setBreak()` to verify if the device declares support for break events, throwing a clean `UnsupportedOperationException` if unsupported (preventing failing control transfers).
3. **Interrupt Endpoint Status Polling**:
   * Implemented a background status-polling thread (`mReadStatusThread`) in `CdcAcmSerialPort` (lazy-started when status is first queried, modeled after the `ProlificSerialDriver` pattern).
   * The thread polls the Interrupt IN endpoint to receive `USB_CDC_NOTIFY_SERIAL_STATE` (0x20) notifications and updates line statuses accordingly.
   * Correctly joined and stopped the polling thread inside `closeInt()`.
4. **Modem/Handshake Line Getters**:
   * Overrode and implemented `getCD()`, `getDSR()`, `getRI()`, and updated `getControlLines()` / `getSupportedControlLines()`.

##### **Unit Testing Added**
* `unionDescriptorDevice()`: Verifies Control/Data interface pairing when probing a device using Union Descriptors and no IAD.
* `acmCapabilitiesAndHandshake()`: Verifies that unsupported break exceptions are thrown, and tests the lazy background polling loop by simulating mocked Interrupt IN status notifications.