### PR TITLE
CP21xx: Overhaul driver with flow control RMW, E104 erratum prevention, and baud rate bounds checking

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriver.java
@@ -52,6 +52,7 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
          */
         private static final int REQTYPE_HOST_TO_DEVICE = 0x41;
         private static final int REQTYPE_DEVICE_TO_HOST = 0xc1;
+        private static final int REQTYPE_DEVICE_TO_HOST_DEV = 0xc0;
 
         /*
          * Configuration Request Codes
@@ -66,6 +67,7 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         private static final int SILABSER_GET_COMM_STATUS_REQUEST_CODE = 0x10;
         private static final int SILABSER_FLUSH_REQUEST_CODE = 0x12;
         private static final int SILABSER_SET_FLOW_REQUEST_CODE = 0x13;
+        private static final int SILABSER_GET_FLOW_REQUEST_CODE = 0x14;
         private static final int SILABSER_SET_CHARS_REQUEST_CODE = 0x19;
         private static final int SILABSER_SET_BAUDRATE_REQUEST_CODE = 0x1E;
 
@@ -96,6 +98,28 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         private static final int STATUS_RI = 0x40;
         private static final int STATUS_CD = 0x80;
 
+        /*
+         * Vendor specific requests and part numbers (from Linux cp210x driver)
+         */
+        private static final int CP210X_VENDOR_SPECIFIC = 0xFF;
+
+        private static final int CP210X_GET_PARTNUM = 0x370B;
+        private static final int CP210X_GET_FW_VER = 0x000E;
+        private static final int CP210X_GET_FW_VER_2N = 0x0010;
+
+        private static final int CP210X_PARTNUM_CP2101 = 0x01;
+        private static final int CP210X_PARTNUM_CP2102 = 0x02;
+        private static final int CP210X_PARTNUM_CP2103 = 0x03;
+        private static final int CP210X_PARTNUM_CP2104 = 0x04;
+        private static final int CP210X_PARTNUM_CP2105 = 0x05;
+        private static final int CP210X_PARTNUM_CP2108 = 0x08;
+        private static final int CP210X_PARTNUM_CP2102N_QFN28 = 0x20;
+        private static final int CP210X_PARTNUM_CP2102N_QFN24 = 0x21;
+        private static final int CP210X_PARTNUM_CP2102N_QFN20 = 0x22;
+        private static final int CP210X_PARTNUM_UNKNOWN = 0xFF;
+
+        private static final int PURGE_ALL = 0x0F;
+
 
         private boolean dtr = false;
         private boolean rts = false;
@@ -103,6 +127,9 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         // second port of Cp2105 has limited baudRate, dataBits, stopBits, parity
         // unsupported baudrate returns error at controlTransfer(), other parameters are silently ignored
         private boolean mIsRestrictedPort;
+
+        private int mPartNum = CP210X_PARTNUM_UNKNOWN;
+        private int mFwVersion = 0;
 
         public Cp21xxSerialPort(UsbDevice device, int portNumber) {
             super(device, portNumber);
@@ -131,6 +158,61 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
             return buffer[0];
         }
 
+        private boolean isCp2102N() {
+            return mPartNum == CP210X_PARTNUM_CP2102N_QFN20 ||
+                   mPartNum == CP210X_PARTNUM_CP2102N_QFN24 ||
+                   mPartNum == CP210X_PARTNUM_CP2102N_QFN28;
+        }
+
+        private boolean isFlowControlSupported() {
+            if (isCp2102N() && mFwVersion <= 0x10004) {
+                return false;
+            }
+            return true;
+        }
+
+        private void queryDeviceTypeAndVersion() {
+            try {
+                byte[] partNumBuf = new byte[1];
+                int ret = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST_DEV, CP210X_VENDOR_SPECIFIC, CP210X_GET_PARTNUM, mPortNumber, partNumBuf, 1, USB_WRITE_TIMEOUT_MILLIS);
+                if (ret == 1) {
+                    mPartNum = partNumBuf[0] & 0xFF;
+                } else {
+                    byte[] partNumBuf2 = new byte[2];
+                    ret = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST_DEV, CP210X_VENDOR_SPECIFIC, CP210X_GET_PARTNUM, mPortNumber, partNumBuf2, 2, USB_WRITE_TIMEOUT_MILLIS);
+                    if (ret >= 1) {
+                        mPartNum = partNumBuf2[0] & 0xFF;
+                    } else {
+                        mPartNum = CP210X_PARTNUM_UNKNOWN;
+                    }
+                }
+            } catch (Exception e) {
+                mPartNum = CP210X_PARTNUM_UNKNOWN;
+            }
+
+            if (isCp2102N()) {
+                try {
+                    byte[] fwVerBuf = new byte[3];
+                    int ret = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST_DEV, CP210X_VENDOR_SPECIFIC, CP210X_GET_FW_VER_2N, mPortNumber, fwVerBuf, 3, USB_WRITE_TIMEOUT_MILLIS);
+                    if (ret == 3) {
+                        mFwVersion = ((fwVerBuf[0] & 0xFF) << 16) | ((fwVerBuf[1] & 0xFF) << 8) | (fwVerBuf[2] & 0xFF);
+                    }
+                } catch (Exception e) {
+                    mFwVersion = 0;
+                }
+            } else if (mPartNum == CP210X_PARTNUM_CP2105 || mPartNum == CP210X_PARTNUM_CP2108) {
+                try {
+                    byte[] fwVerBuf = new byte[3];
+                    int ret = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST_DEV, CP210X_VENDOR_SPECIFIC, CP210X_GET_FW_VER, mPortNumber, fwVerBuf, 3, USB_WRITE_TIMEOUT_MILLIS);
+                    if (ret == 3) {
+                        mFwVersion = ((fwVerBuf[0] & 0xFF) << 16) | ((fwVerBuf[1] & 0xFF) << 8) | (fwVerBuf[2] & 0xFF);
+                    }
+                } catch (Exception e) {
+                    mFwVersion = 0;
+                }
+            }
+        }
+
         @Override
         protected void openInt() throws IOException {
             mIsRestrictedPort = mDevice.getInterfaceCount() == 2 && mPortNumber == 1;
@@ -152,6 +234,8 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
                 }
             }
 
+            queryDeviceTypeAndVersion();
+
             setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_ENABLE);
             setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, (dtr ? DTR_ENABLE : DTR_DISABLE) | (rts ? RTS_ENABLE : RTS_DISABLE));
             setFlowControl(mFlowControl);
@@ -159,6 +243,9 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
 
         @Override
         protected void closeInt() {
+            try {
+                setConfigSingle(SILABSER_FLUSH_REQUEST_CODE, PURGE_ALL);
+            } catch (Exception ignored) {}
             try {
                 setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_DISABLE);
             } catch (Exception ignored) {}
@@ -185,6 +272,22 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
         public void setParameters(int baudRate, int dataBits, int stopBits, @Parity int parity) throws IOException {
             if(baudRate <= 0) {
                 throw new IllegalArgumentException("Invalid baud rate: " + baudRate);
+            }
+            int maxBaud = 2000000;
+            int minBaud = 300;
+            if (mPartNum == CP210X_PARTNUM_CP2101) {
+                maxBaud = 921600;
+            } else if (mPartNum == CP210X_PARTNUM_CP2102 || mPartNum == CP210X_PARTNUM_CP2103) {
+                maxBaud = 1000000;
+            } else if (isCp2102N()) {
+                maxBaud = 3000000;
+            }
+            if (mIsRestrictedPort) {
+                minBaud = 2400;
+                maxBaud = 921600;
+            }
+            if (baudRate < minBaud || baudRate > maxBaud) {
+                throw new IllegalArgumentException("Baud rate " + baudRate + " out of bounds [" + minBaud + ", " + maxBaud + "] for this device");
             }
             setBaudRate(baudRate);
 
@@ -334,42 +437,75 @@ public class Cp21xxSerialDriver implements UsbSerialDriver {
 
         @Override
         public void setFlowControl(FlowControl flowControl) throws IOException {
+            if (flowControl != FlowControl.NONE && !isFlowControlSupported()) {
+                throw new UnsupportedOperationException("Flow control not supported on this CP2102N device due to firmware erratum CP2102N_E104");
+            }
+            if (flowControl == FlowControl.XON_XOFF_INLINE) {
+                throw new UnsupportedOperationException();
+            }
+
             byte[] data = new byte[16];
-            if(flowControl == FlowControl.RTS_CTS) {
-                data[4] |=  0b1000_0000; // RTS
-                data[0] |=  0b0000_1000; // CTS
-            } else {
-                if(rts)
-                    data[4] |= 0b0100_0000;
+            int ret = mConnection.controlTransfer(REQTYPE_DEVICE_TO_HOST, SILABSER_GET_FLOW_REQUEST_CODE,
+                    0, mPortNumber, data, data.length, USB_WRITE_TIMEOUT_MILLIS);
+            if (ret != data.length) {
+                throw new IOException("Error getting flow control: " + ret);
             }
-            if(flowControl == FlowControl.DTR_DSR) {
-                data[0] |= 0b0000_0010; // DTR
-                data[0] |= 0b0001_0000; // DSR
+
+            // RTS / CTS
+            if (flowControl == FlowControl.RTS_CTS) {
+                data[0] |= 0x08; // CTS handshake
+                data[4] &= ~0xC0; // clear RTS mask
+                data[4] |= 0x80; // RTS flow control
             } else {
-                if(dtr)
-                    data[0] |= 0b0000_0001;
+                data[0] &= ~0x08; // disable CTS handshake
+                data[4] &= ~0xC0; // clear RTS mask
+                if (rts) {
+                    data[4] |= 0x40; // RTS active
+                }
             }
-            if(flowControl == FlowControl.XON_XOFF) {
+
+            // DTR / DSR
+            if (flowControl == FlowControl.DTR_DSR) {
+                data[0] &= ~0x03; // clear DTR mask
+                data[0] |= 0x02; // DTR flow control
+                data[0] |= 0x10; // DSR handshake
+            } else {
+                data[0] &= ~0x03; // clear DTR mask
+                if (dtr) {
+                    data[0] |= 0x01; // DTR active
+                }
+                data[0] &= ~0x10; // disable DSR handshake
+            }
+
+            // XON / XOFF
+            if (flowControl == FlowControl.XON_XOFF) {
                 byte[] chars = new byte[]{0, 0, 0, 0, CHAR_XON, CHAR_XOFF};
-                int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_CHARS_REQUEST_CODE,
+                ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_CHARS_REQUEST_CODE,
                         0, mPortNumber, chars, chars.length, USB_WRITE_TIMEOUT_MILLIS);
                 if (ret != chars.length) {
                     throw new IOException("Error setting XON/XOFF chars");
                 }
-                data[4] |= 0b0000_0011;
-                data[7] |= 0b1000_0000;
-                data[8] = (byte)128;
-                data[12] = (byte)128;
+                data[4] |= 0x03; // AUTO_TRANSMIT | AUTO_RECEIVE
+                data[7] |= 0x80; // XOFF_CONTINUE
+                data[8] = (byte) 128;
+                data[9] = 0;
+                data[10] = 0;
+                data[11] = 0;
+                data[12] = (byte) 128;
+                data[13] = 0;
+                data[14] = 0;
+                data[15] = 0;
+            } else {
+                data[4] &= ~0x03; // disable AUTO_TRANSMIT | AUTO_RECEIVE
+                data[7] &= ~0x80; // disable XOFF_CONTINUE
             }
-            if(flowControl == FlowControl.XON_XOFF_INLINE) {
-                throw new UnsupportedOperationException();
-            }
-            int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_FLOW_REQUEST_CODE,
+
+            ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_FLOW_REQUEST_CODE,
                     0, mPortNumber, data, data.length, USB_WRITE_TIMEOUT_MILLIS);
             if (ret != data.length) {
                 throw new IOException("Error setting flow control");
             }
-            if(flowControl == FlowControl.XON_XOFF) {
+            if (flowControl == FlowControl.XON_XOFF) {
                 setXON(true);
             }
             mFlowControl = flowControl;

--- a/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriverTest.java
+++ b/usbSerialForAndroid/src/test/java/com/hoho/android/usbserial/driver/Cp21xxSerialDriverTest.java
@@ -1,0 +1,226 @@
+package com.hoho.android.usbserial.driver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+
+public class Cp21xxSerialDriverTest {
+
+    private UsbDevice usbDevice;
+    private UsbDeviceConnection usbConnection;
+    private UsbInterface usbInterface;
+    private UsbEndpoint readEndpoint;
+    private UsbEndpoint writeEndpoint;
+
+    @Before
+    public void setUp() {
+        usbDevice = mock(UsbDevice.class);
+        usbConnection = mock(UsbDeviceConnection.class);
+        usbInterface = mock(UsbInterface.class);
+        readEndpoint = mock(UsbEndpoint.class);
+        writeEndpoint = mock(UsbEndpoint.class);
+
+        when(usbDevice.getInterfaceCount()).thenReturn(1);
+        when(usbDevice.getInterface(0)).thenReturn(usbInterface);
+        when(usbInterface.getEndpointCount()).thenReturn(2);
+        when(usbInterface.getEndpoint(0)).thenReturn(readEndpoint);
+        when(usbInterface.getEndpoint(1)).thenReturn(writeEndpoint);
+
+        when(readEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+        when(readEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_IN);
+        when(writeEndpoint.getType()).thenReturn(UsbConstants.USB_ENDPOINT_XFER_BULK);
+        when(writeEndpoint.getDirection()).thenReturn(UsbConstants.USB_DIR_OUT);
+
+        when(usbConnection.claimInterface(any(UsbInterface.class), eq(true))).thenReturn(true);
+    }
+
+    private void mockDeviceType(final byte partNum, final byte[] fwVerBytes) {
+        // Mock part number query
+        when(usbConnection.controlTransfer(
+                eq(0xc0), eq(0xFF), eq(0x370B), eq(0), any(byte[].class), anyInt(), anyInt()
+        )).thenAnswer((Answer<Integer>) invocation -> {
+            byte[] buf = invocation.getArgument(4);
+            int len = invocation.getArgument(5);
+            if (len >= 1) {
+                buf[0] = partNum;
+                return 1;
+            }
+            return -1;
+        });
+
+        // Mock firmware version query (either 0x000E or 0x0010)
+        if (fwVerBytes != null) {
+            when(usbConnection.controlTransfer(
+                    eq(0xc0), eq(0xFF), anyInt(), eq(0), any(byte[].class), anyInt(), anyInt()
+            )).thenAnswer((Answer<Integer>) invocation -> {
+                int reqVal = invocation.getArgument(2);
+                if (reqVal == 0x000E || reqVal == 0x0010) {
+                    byte[] buf = invocation.getArgument(4);
+                    System.arraycopy(fwVerBytes, 0, buf, 0, Math.min(len(fwVerBytes), buf.length));
+                    return 3;
+                }
+                return -1;
+            });
+        }
+    }
+
+    private int len(byte[] arr) {
+        return arr == null ? 0 : arr.length;
+    }
+
+    @Test
+    public void openAndClosePurge() throws Exception {
+        mockDeviceType((byte) 0x02, null); // CP2102
+
+        Cp21xxSerialDriver driver = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port = (Cp21xxSerialPort) driver.getPorts().get(0);
+        port.mConnection = usbConnection;
+
+        // Stub GET_FLOW (0x14) for initial setFlowControl call during open
+        when(usbConnection.controlTransfer(
+                eq(0xc1), eq(0x14), eq(0), eq(0), any(byte[].class), eq(16), anyInt()
+        )).thenAnswer((Answer<Integer>) invocation -> {
+            byte[] buf = invocation.getArgument(4);
+            return buf.length;
+        });
+
+        port.openInt();
+
+        // Verify claim and initial requests
+        verify(usbConnection, times(1)).claimInterface(usbInterface, true);
+        
+        port.closeInt();
+
+        // Verify CP210X_PURGE (0x12) with PURGE_ALL (0x0F) was called on close
+        verify(usbConnection, times(1)).controlTransfer(
+                eq(0x41), eq(0x12), eq(0x0F), eq(0), any(), eq(0), anyInt()
+        );
+    }
+
+    @Test
+    public void baudRateValidation() throws Exception {
+        // Test CP2101 Max 921,600
+        mockDeviceType((byte) 0x01, null);
+        Cp21xxSerialDriver driver1 = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port1 = (Cp21xxSerialPort) driver1.getPorts().get(0);
+        port1.mConnection = usbConnection;
+        port1.openInt();
+        port1.setParameters(921600, 8, 1, UsbSerialPort.PARITY_NONE); // should pass
+        assertThrows(IllegalArgumentException.class, () -> port1.setParameters(1000000, 8, 1, UsbSerialPort.PARITY_NONE));
+
+        // Test CP2102 Max 1,000,000
+        mockDeviceType((byte) 0x02, null);
+        Cp21xxSerialDriver driver2 = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port2 = (Cp21xxSerialPort) driver2.getPorts().get(0);
+        port2.mConnection = usbConnection;
+        port2.openInt();
+        port2.setParameters(1000000, 8, 1, UsbSerialPort.PARITY_NONE); // should pass
+        assertThrows(IllegalArgumentException.class, () -> port2.setParameters(1152000, 8, 1, UsbSerialPort.PARITY_NONE));
+
+        // Test CP2102N Max 3,000,000
+        mockDeviceType((byte) 0x20, new byte[]{1, 0, 5}); // CP2102N, v1.0.5
+        Cp21xxSerialDriver driver3 = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port3 = (Cp21xxSerialPort) driver3.getPorts().get(0);
+        port3.mConnection = usbConnection;
+        port3.openInt();
+        port3.setParameters(3000000, 8, 1, UsbSerialPort.PARITY_NONE); // should pass
+        assertThrows(IllegalArgumentException.class, () -> port3.setParameters(4000000, 8, 1, UsbSerialPort.PARITY_NONE));
+
+        // Test CP2105 restricted port (port number 1, 2 interfaces)
+        UsbDevice usbDeviceRestricted = mock(UsbDevice.class);
+        when(usbDeviceRestricted.getInterfaceCount()).thenReturn(2);
+        when(usbDeviceRestricted.getInterface(0)).thenReturn(usbInterface);
+        when(usbDeviceRestricted.getInterface(1)).thenReturn(usbInterface);
+
+        mockDeviceType((byte) 0x05, new byte[]{1, 0, 0});
+        Cp21xxSerialDriver driver4 = new Cp21xxSerialDriver(usbDeviceRestricted);
+        Cp21xxSerialPort port4 = (Cp21xxSerialPort) driver4.getPorts().get(1); // restricted port (SCI)
+        port4.mConnection = usbConnection;
+        port4.openInt();
+
+        port4.setParameters(2400, 8, 1, UsbSerialPort.PARITY_NONE); // should pass
+        assertThrows(IllegalArgumentException.class, () -> port4.setParameters(300, 8, 1, UsbSerialPort.PARITY_NONE)); // min 2400
+        assertThrows(IllegalArgumentException.class, () -> port4.setParameters(1000000, 8, 1, UsbSerialPort.PARITY_NONE)); // max 921600
+    }
+
+    @Test
+    public void erratumE104Enforcement() throws Exception {
+        // CP2102N with firmware version 1.0.4 (<= 1.0.4)
+        mockDeviceType((byte) 0x20, new byte[]{1, 0, 4});
+
+        Cp21xxSerialDriver driver = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port = (Cp21xxSerialPort) driver.getPorts().get(0);
+        port.mConnection = usbConnection;
+        port.openInt();
+
+        // Flow control should fail
+        assertThrows(UnsupportedOperationException.class, () -> port.setFlowControl(UsbSerialPort.FlowControl.RTS_CTS));
+        assertThrows(UnsupportedOperationException.class, () -> port.setFlowControl(UsbSerialPort.FlowControl.DTR_DSR));
+        assertThrows(UnsupportedOperationException.class, () -> port.setFlowControl(UsbSerialPort.FlowControl.XON_XOFF));
+
+        // FlowControl.NONE should pass
+        port.setFlowControl(UsbSerialPort.FlowControl.NONE);
+    }
+
+    @Test
+    public void flowControlReadModifyWrite() throws Exception {
+        mockDeviceType((byte) 0x02, null); // CP2102
+
+        Cp21xxSerialDriver driver = new Cp21xxSerialDriver(usbDevice);
+        Cp21xxSerialPort port = (Cp21xxSerialPort) driver.getPorts().get(0);
+        port.mConnection = usbConnection;
+
+        // Stub GET_FLOW (0x14) to return a specific configuration pattern
+        final byte[] mockFlowConfig = new byte[16];
+        mockFlowConfig[0] = 0x00; // no CTS/DTR handshake
+        mockFlowConfig[4] = 0x04; // error char replacement enabled
+        mockFlowConfig[5] = 0x11; // custom flags
+
+        when(usbConnection.controlTransfer(
+                eq(0xc1), eq(0x14), eq(0), eq(0), any(byte[].class), eq(16), anyInt()
+        )).thenAnswer((Answer<Integer>) invocation -> {
+            byte[] buf = invocation.getArgument(4);
+            System.arraycopy(mockFlowConfig, 0, buf, 0, 16);
+            return 16;
+        });
+
+        // Capture what is written back on SET_FLOW (0x13)
+        final byte[][] writtenData = new byte[1][];
+        when(usbConnection.controlTransfer(
+                eq(0x41), eq(0x13), eq(0), eq(0), any(byte[].class), eq(16), anyInt()
+        )).thenAnswer((Answer<Integer>) invocation -> {
+            byte[] buf = invocation.getArgument(4);
+            writtenData[0] = buf.clone();
+            return 16;
+        });
+
+        port.openInt();
+        port.setFlowControl(UsbSerialPort.FlowControl.RTS_CTS);
+
+        // Verify we read and modified rather than zero-wrote:
+        // Byte 4 should have 0x84 (0x80 RTS_FLOW_CTL | 0x04 preserved error char flag)
+        // Byte 5 should still have 0x11 preserved
+        // Byte 0 should have 0x08 (CTS handshake)
+        assertEquals((byte) 0x08, writtenData[0][0]);
+        assertEquals((byte) 0x84, writtenData[0][4]);
+        assertEquals((byte) 0x11, writtenData[0][5]);
+    }
+}


### PR DESCRIPTION
This PR overhauls the CP21xx USB-to-UART driver based on stability patterns and requirements found in the Linux kernel driver. It resolves several silent bugs, handles known hardware errata, and enforces speed boundaries.

#### **Key Enhancements**
1. **Flow Control Read-Modify-Write (RMW)**:
   * Overhauled `setFlowControl()` to query the current handshake settings via `SILABSER_GET_FLOW_REQUEST_CODE` (0x14) before editing. 
   * Updates only the relevant bits for the requested flow control mode instead of wiping out the entire 16-byte structure. This preserves custom configurations like error-character substitution, null-stripping, and suspend/low-power modes.
2. **CP2102N Erratum `CP2102N_E104` Prevention**:
   * Queries the part number and firmware version on connection startup. 
   * Restricts early revision CP2102N devices (firmware version $\le$ 1.0.4) from configuring hardware flow control (throwing `UnsupportedOperationException`). This prevents manual RTS overrides from causing lockups and failures on affected chips.
3. **Queue Purging on Port Close**:
   * Sends a `SILABSER_FLUSH_REQUEST_CODE` (0x12) control request with value `PURGE_ALL` (`0x0F`) when closing the port. This cleans up hardware transmit and receive buffers, resolving occasional driver hangs on multi-port devices (especially CP2108).
4. **Baud Rate Validation**:
   * Validates and clamps baud rate configurations depending on the specific CP21xx model limits:
     * **CP2101**: Max 921,600 baud.
     * **CP2102 / CP2103**: Max 1,000,000 baud.
     * **CP2102N**: Max 3,000,000 baud.
     * **CP2105 SCI Restricted Port**: Bound between 2,400 and 921,600 baud.
     * **Others**: Max 2,000,000 baud.