### PR TITLE
Prolific: Improve serial driver flow control and baud rate configuration

### DIFF
--- a/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/usbSerialForAndroid/src/main/java/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -30,9 +30,9 @@ public class ProlificSerialDriver implements UsbSerialDriver {
     private final String TAG = ProlificSerialDriver.class.getSimpleName();
 
     private final static int[] standardBaudRates = {
-            75, 150, 300, 600, 1200, 1800, 2400, 3600, 4800, 7200, 9600, 14400, 19200,
-            28800, 38400, 57600, 115200, 128000, 134400, 161280, 201600, 230400, 268800,
-            403200, 460800, 614400, 806400, 921600, 1228800, 2457600, 3000000, 6000000
+            75, 150, 300, 600, 1200, 1800, 2400, 3600, 4800, 7200, 9600,
+            14400, 19200, 28800, 38400, 57600, 115200, 230400, 460800,
+            614400, 921600, 1228800, 2457600, 3000000, 6000000
     };
     protected enum DeviceType { DEVICE_TYPE_01, DEVICE_TYPE_T, DEVICE_TYPE_HX, DEVICE_TYPE_HXN }
 
@@ -159,6 +159,20 @@ public class ProlificSerialDriver implements UsbSerialDriver {
         private void vendorOut(int value, int index, byte[] data) throws IOException {
             int request = (mDeviceType == DeviceType.DEVICE_TYPE_HXN) ? VENDOR_WRITE_HXN_REQUEST : VENDOR_WRITE_REQUEST;
             outControlTransfer(VENDOR_OUT_REQTYPE, request, value, index, data);
+        }
+
+        private void updateReg(int reg, int mask, int val) throws IOException {
+            int current;
+            if (mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
+                byte[] data = vendorIn(reg, 0, 1);
+                current = data[0] & 0xff;
+            } else {
+                byte[] data = vendorIn(reg | 0x80, 0, 1);
+                current = data[0] & 0xff;
+            }
+            current &= ~mask;
+            current |= val & mask;
+            vendorOut(reg, current, null);
         }
 
         private void resetDevice() throws IOException {
@@ -547,28 +561,26 @@ public class ProlificSerialDriver implements UsbSerialDriver {
 
         @Override
         public void setFlowControl(FlowControl flowControl) throws IOException {
-            // vendorOut values from https://www.mail-archive.com/linux-usb@vger.kernel.org/msg110968.html
-            switch (flowControl) {
-                case NONE:
-                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
-                        vendorOut(0x0a, 0xff, null);
-                    else
-                        vendorOut(0, 0, null);
-                    break;
-                case RTS_CTS:
-                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
-                        vendorOut(0x0a, 0xfa, null);
-                    else
-                        vendorOut(0, 0x61, null);
-                    break;
-                case XON_XOFF_INLINE:
-                    if (mDeviceType == DeviceType.DEVICE_TYPE_HXN)
-                        vendorOut(0x0a, 0xee, null);
-                    else
-                        vendorOut(0, 0xc1, null);
-                    break;
-                default:
-                    throw new UnsupportedOperationException();
+            if (mDeviceType == DeviceType.DEVICE_TYPE_HXN) {
+                int val;
+                switch (flowControl) {
+                    case NONE: val = 0x1c; break;
+                    case RTS_CTS: val = 0x18; break;
+                    case XON_XOFF_INLINE: val = 0x0c; break;
+                    default: throw new UnsupportedOperationException();
+                }
+                updateReg(0x0a, 0x1c, val);
+            } else {
+                int val;
+                switch (flowControl) {
+                    case NONE: val = 0; break;
+                    case RTS_CTS:
+                        val = (mDeviceType == DeviceType.DEVICE_TYPE_01) ? 0x40 : 0x60;
+                        break;
+                    case XON_XOFF_INLINE: val = 0xc0; break;
+                    default: throw new UnsupportedOperationException();
+                }
+                updateReg(0, 0xf0, val);
             }
             mFlowControl = flowControl;
         }


### PR DESCRIPTION
This pull request introduces two improvements to the Prolific serial driver (`ProlificSerialDriver`) to increase safety and expand hardware compatibility.

## Summary of Changes

### 1. Safe Read-Modify-Write for Flow Control Configuration
- **Issue**: Previously, setting flow control directly overwrote registers (register `0` for older chips, register `0x0a` for HXN chips) with static hardcoded values. This was unsafe as it unconditionally cleared all other configuration/status bits stored in those registers.
- **Solution**: Implemented a private `updateReg` helper method that reads the current register contents, masks out only the flow-control-related bits, overlays the new configuration, and writes the byte back. This ensures all other hardware settings are preserved.
- **Legacy Support**: Handled legacy chips (`DEVICE_TYPE_01`) specifically by configuring their RTS/CTS flow control register value to `0x40` (instead of `0x60` used on newer chip variants).

### 2. Baud Rate Alignment for Older Hardware Compatibility
- **Issue**: The `standardBaudRates` array contained several baud rates (`128000, 134400, 161280, 201600, 268800, 403200, 806400`) that are not supported directly in hardware by older/legacy Prolific chips. Direct speed configuration for these rates would fail or cause silent fallbacks to 9600 baud.
- **Solution**: Removed these non-direct baud rates from `standardBaudRates`. Removing them forces the driver to utilize the divisor-encoding logic to compute and set correct hardware divisors, which successfully establishes these baud rates on older hardware configurations.